### PR TITLE
Add entities for assemblies and scaffolds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+		<!-- Embedded H2 database for testing and CI testing -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+			<version>1.4.199</version>
+		</dependency>
+
     </dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,12 @@
 			<artifactId>commons-net</artifactId>
 			<version>3.6</version>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/ebivariation/contigalias/dus/FTPBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/FTPBrowser.java
@@ -45,7 +45,7 @@ public class FTPBrowser {
             logger.info("Connected successfully to {}", address);
         } catch (Exception e) {
             logger.error("Could not connect to FTP server '{}'. FTP status was: {}. Reply code: {}. Reply string: {}",
-                    address, ftp.getStatus(), ftp.getReply(), ftp.getReplyString());
+                         address, ftp.getStatus(), ftp.getReply(), ftp.getReplyString());
             ftp.disconnect();
             throw e;
         }

--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 public class NCBIBrowser extends FTPBrowser {
 
     public static final String NCBI_FTP_SERVER = "ftp.ncbi.nlm.nih.gov";
+
     public static final String PATH_GENOMES_ALL = "/genomes/all/";
 
     public void connect() throws IOException {
@@ -24,6 +25,7 @@ public class NCBIBrowser extends FTPBrowser {
     /**
      * Takes a Genbank or Refseq accession and converts it to the equivalent path used by NCBI's FTP server.
      * For example, on input "GCF_007608995.1" the output path is "GCF/007/608/995/GCF_007608995.1_ASM760899v1/".
+     *
      * @param accession Any GCA or GCF String
      * @return Path relative to ftp.ncbi.nlm.nih.gov/genomes/all/
      * @throws IOException Passes exception thrown by FTPBrowser.listDirectories()

--- a/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
@@ -13,9 +13,13 @@ public class AssemblyEntity {
     private long id;
 
     private String name;
+
     private String organism;
+
     private long taxid;
+
     private String genbank;
+
     private String refseq;
 
     @OneToMany(mappedBy = "assembly", cascade = CascadeType.ALL)

--- a/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
@@ -83,4 +83,7 @@ public class AssemblyEntity {
         this.scaffolds = scaffolds;
         return this;
     }
+
+    public AssemblyEntity() {
+    }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
@@ -19,7 +19,7 @@ public class AssemblyEntity {
     private String refseq;
 
     @OneToMany(mappedBy = "assembly", cascade = CascadeType.ALL)
-    private List<ScaffoldEntity> scaffolds;
+    private List<ChromosomeEntity> chromosomes;
 
     public long getId() {
         return id;
@@ -45,8 +45,8 @@ public class AssemblyEntity {
         return refseq;
     }
 
-    public List<ScaffoldEntity> getScaffolds() {
-        return scaffolds;
+    public List<ChromosomeEntity> getChromosomes() {
+        return chromosomes;
     }
 
     public AssemblyEntity setId(long id) {
@@ -79,8 +79,8 @@ public class AssemblyEntity {
         return this;
     }
 
-    public AssemblyEntity setScaffolds(List<ScaffoldEntity> scaffolds) {
-        this.scaffolds = scaffolds;
+    public AssemblyEntity setChromosomes(List<ChromosomeEntity> scaffolds) {
+        this.chromosomes = scaffolds;
         return this;
     }
 

--- a/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
@@ -25,6 +25,9 @@ public class AssemblyEntity {
     @OneToMany(mappedBy = "assembly", cascade = CascadeType.ALL)
     private List<ChromosomeEntity> chromosomes;
 
+    public AssemblyEntity() {
+    }
+
     public long getId() {
         return id;
     }
@@ -88,6 +91,4 @@ public class AssemblyEntity {
         return this;
     }
 
-    public AssemblyEntity() {
-    }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
@@ -1,0 +1,16 @@
+package com.ebivariation.contigalias.entities;
+
+import java.util.List;
+
+public class AssemblyEntity {
+
+    private long id;
+    private String name;
+    private String organism;
+    private long taxid;
+    private String genbank;
+    private String refseq;
+
+    private List<ScaffoldEntity> scaffolds;
+
+}

--- a/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/AssemblyEntity.java
@@ -1,16 +1,86 @@
 package com.ebivariation.contigalias.entities;
 
+import javax.persistence.*;
 import java.util.List;
 
+@Entity
+@Table
 public class AssemblyEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(nullable = false)
     private long id;
+
     private String name;
     private String organism;
     private long taxid;
     private String genbank;
     private String refseq;
 
+    @OneToMany(mappedBy = "assembly", cascade = CascadeType.ALL)
     private List<ScaffoldEntity> scaffolds;
 
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getOrganism() {
+        return organism;
+    }
+
+    public long getTaxid() {
+        return taxid;
+    }
+
+    public String getGenbank() {
+        return genbank;
+    }
+
+    public String getRefseq() {
+        return refseq;
+    }
+
+    public List<ScaffoldEntity> getScaffolds() {
+        return scaffolds;
+    }
+
+    public AssemblyEntity setId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public AssemblyEntity setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public AssemblyEntity setOrganism(String organism) {
+        this.organism = organism;
+        return this;
+    }
+
+    public AssemblyEntity setTaxid(long taxid) {
+        this.taxid = taxid;
+        return this;
+    }
+
+    public AssemblyEntity setGenbank(String genbank) {
+        this.genbank = genbank;
+        return this;
+    }
+
+    public AssemblyEntity setRefseq(String refseq) {
+        this.refseq = refseq;
+        return this;
+    }
+
+    public AssemblyEntity setScaffolds(List<ScaffoldEntity> scaffolds) {
+        this.scaffolds = scaffolds;
+        return this;
+    }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
@@ -14,9 +14,6 @@ import javax.persistence.GenerationType;
 @Table
 public class ChromosomeEntity {
 
-    public ChromosomeEntity() {
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(nullable = false)

--- a/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
@@ -1,17 +1,31 @@
 package com.ebivariation.contigalias.entities;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Id;
+import javax.persistence.GenerationType;
+
 
 @Entity
 @Table
 public class ChromosomeEntity {
 
+    public ChromosomeEntity() {
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(nullable = false)
     private long id;
+
     private String name;
+
     private String genbank;
+
     private String refseq;
 
     @ManyToOne(cascade = CascadeType.ALL)
@@ -62,6 +76,4 @@ public class ChromosomeEntity {
         return this;
     }
 
-    public ChromosomeEntity() {
-    }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
@@ -76,4 +76,6 @@ public class ChromosomeEntity {
         return this;
     }
 
+    public ChromosomeEntity() {
+    }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
@@ -4,7 +4,7 @@ import javax.persistence.*;
 
 @Entity
 @Table
-public class ScaffoldEntity {
+public class ChromosomeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -37,31 +37,31 @@ public class ScaffoldEntity {
         return assembly;
     }
 
-    public ScaffoldEntity setId(long id) {
+    public ChromosomeEntity setId(long id) {
         this.id = id;
         return this;
     }
 
-    public ScaffoldEntity setName(String name) {
+    public ChromosomeEntity setName(String name) {
         this.name = name;
         return this;
     }
 
-    public ScaffoldEntity setGenbank(String genbank) {
+    public ChromosomeEntity setGenbank(String genbank) {
         this.genbank = genbank;
         return this;
     }
 
-    public ScaffoldEntity setRefseq(String refseq) {
+    public ChromosomeEntity setRefseq(String refseq) {
         this.refseq = refseq;
         return this;
     }
 
-    public ScaffoldEntity setAssembly(AssemblyEntity assembly) {
+    public ChromosomeEntity setAssembly(AssemblyEntity assembly) {
         this.assembly = assembly;
         return this;
     }
 
-    public ScaffoldEntity() {
+    public ChromosomeEntity() {
     }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
@@ -14,6 +14,9 @@ import javax.persistence.GenerationType;
 @Table
 public class ChromosomeEntity {
 
+    public ChromosomeEntity() {
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(nullable = false)
@@ -76,6 +79,4 @@ public class ChromosomeEntity {
         return this;
     }
 
-    public ChromosomeEntity() {
-    }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ChromosomeEntity.java
@@ -14,9 +14,6 @@ import javax.persistence.GenerationType;
 @Table
 public class ChromosomeEntity {
 
-    public ChromosomeEntity() {
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(nullable = false)
@@ -30,6 +27,9 @@ public class ChromosomeEntity {
 
     @ManyToOne(cascade = CascadeType.ALL)
     private AssemblyEntity assembly;
+
+    public ChromosomeEntity() {
+    }
 
     public long getId() {
         return id;

--- a/src/main/java/com/ebivariation/contigalias/entities/ScaffoldEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ScaffoldEntity.java
@@ -61,4 +61,7 @@ public class ScaffoldEntity {
         this.assembly = assembly;
         return this;
     }
+
+    public ScaffoldEntity() {
+    }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/ScaffoldEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ScaffoldEntity.java
@@ -1,12 +1,64 @@
 package com.ebivariation.contigalias.entities;
 
+import javax.persistence.*;
+
+@Entity
+@Table
 public class ScaffoldEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(nullable = false)
     private long id;
     private String name;
     private String genbank;
     private String refseq;
 
+    @ManyToOne(cascade = CascadeType.ALL)
     private AssemblyEntity assembly;
 
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getGenbank() {
+        return genbank;
+    }
+
+    public String getRefseq() {
+        return refseq;
+    }
+
+    public AssemblyEntity getAssembly() {
+        return assembly;
+    }
+
+    public ScaffoldEntity setId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public ScaffoldEntity setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ScaffoldEntity setGenbank(String genbank) {
+        this.genbank = genbank;
+        return this;
+    }
+
+    public ScaffoldEntity setRefseq(String refseq) {
+        this.refseq = refseq;
+        return this;
+    }
+
+    public ScaffoldEntity setAssembly(AssemblyEntity assembly) {
+        this.assembly = assembly;
+        return this;
+    }
 }

--- a/src/main/java/com/ebivariation/contigalias/entities/ScaffoldEntity.java
+++ b/src/main/java/com/ebivariation/contigalias/entities/ScaffoldEntity.java
@@ -1,0 +1,12 @@
+package com.ebivariation.contigalias.entities;
+
+public class ScaffoldEntity {
+
+    private long id;
+    private String name;
+    private String genbank;
+    private String refseq;
+
+    private AssemblyEntity assembly;
+
+}

--- a/src/test/java/com/ebivariation/contigalias/ContigAliasApplicationTests.java
+++ b/src/test/java/com/ebivariation/contigalias/ContigAliasApplicationTests.java
@@ -6,13 +6,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ContigAliasApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
-	@Test
-	void actionsTest(){
-		System.out.println("Github actions is running tests.");
-	}
+    @Test
+    void actionsTest() {
+        System.out.println("Github actions is running tests.");
+    }
 
 }

--- a/src/test/java/com/ebivariation/contigalias/FTPBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/FTPBrowserTest.java
@@ -53,7 +53,7 @@ public class FTPBrowserTest {
             assertTrue(ftpFiles.length > 0);
             String assemblyReport = "GCA_000002305.1_EquCab2.0_assembly_report.txt";
             boolean found = Stream.of(ftpFiles)
-                    .anyMatch(f -> f.getName().contains(assemblyReport));
+                                  .anyMatch(f -> f.getName().contains(assemblyReport));
             assertTrue(found, "didn't find the assembly report '" + assemblyReport + "' in the folder. Contents are:\n"
                     + Stream.of(ftpFiles).map(FTPFile::toString).collect(Collectors.joining("\n")));
         }

--- a/src/test/java/com/ebivariation/contigalias/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/NCBIBrowserTest.java
@@ -32,26 +32,26 @@ public class NCBIBrowserTest {
 
     @Test
     void navigateToAllGenomesDirectory() throws IOException {
-            ncbiBrowser.navigateToAllGenomesDirectory();
-            assertTrue(ncbiBrowser.listFiles().length > 0);
+        ncbiBrowser.navigateToAllGenomesDirectory();
+        assertTrue(ncbiBrowser.listFiles().length > 0);
     }
 
     @Test
     void navigateToSubDirectoryPath() throws IOException {
-            ncbiBrowser.navigateToSubDirectoryPath("/genomes/INFLUENZA/");
-            assertTrue(ncbiBrowser.listFiles().length > 0);
+        ncbiBrowser.navigateToSubDirectoryPath("/genomes/INFLUENZA/");
+        assertTrue(ncbiBrowser.listFiles().length > 0);
     }
 
     @Test
     void getGenomeReportDirectoryGCATest() throws IOException {
-            String path = ncbiBrowser.getGenomeReportDirectory("GCA_004051055.1");
-            assertEquals("GCA/004/051/055/GCA_004051055.1_ASM405105v1/", path);
+        String path = ncbiBrowser.getGenomeReportDirectory("GCA_004051055.1");
+        assertEquals("GCA/004/051/055/GCA_004051055.1_ASM405105v1/", path);
     }
 
     @Test
     void getGenomeReportDirectoryGCFTest() throws IOException {
-            String path = ncbiBrowser.getGenomeReportDirectory("GCF_007608995.1");
-            assertEquals("GCF/007/608/995/GCF_007608995.1_ASM760899v1/", path);
+        String path = ncbiBrowser.getGenomeReportDirectory("GCF_007608995.1");
+        assertEquals("GCF/007/608/995/GCF_007608995.1_ASM760899v1/", path);
     }
 
 }


### PR DESCRIPTION
I have added entites which will be used to store data in the database in the future. They are presentely required to convert parsed data from csv files into java objects.
An H2 database has been added as a dependency to let the application run without having to set up the database at this stage.