### PR TITLE
FTPBrowser (here PassiveAnonymousFTPClient) now extends FTPClient

### DIFF
--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -34,12 +34,8 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
         super.connect(NCBI_FTP_SERVER);
     }
 
-    public void navigateToSubDirectoryPath(String path) throws IOException {
-        super.navigateToDirectory(path);
-    }
-
-    public void navigateToAllGenomesDirectory() throws IOException {
-        navigateToSubDirectoryPath(PATH_GENOMES_ALL);
+    public boolean changeWorkingDirectoryToGenomesAll() throws IOException {
+        return super.changeWorkingDirectory(PATH_GENOMES_ALL);
     }
 
     /**
@@ -89,7 +85,8 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
     }
 
     /**
-     * @param directoryPath The path of the directory in which target report is located related to current directory.
+     * @param directoryPath The path of the directory in which target report is located relative to root of FTP server.
+     *                      Eg:- "/genomes/all/GCF/007/608/995/GCF_007608995.1_ASM760899v1/"
      * @return An InputStream of the first *assembly_report.txt file it finds.
      * @throws IOException Passes exception thrown by FTPBrowser.retrieveFileStream()
      */

--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public class NCBIBrowser extends FTPBrowser {
+public class NCBIBrowser extends PassiveAnonymousFTPClient {
 
     public static final String NCBI_FTP_SERVER = "ftp.ncbi.nlm.nih.gov";
 

--- a/src/main/java/com/ebivariation/contigalias/dus/PassiveAnonymousFTPClient.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/PassiveAnonymousFTPClient.java
@@ -73,10 +73,4 @@ public class PassiveAnonymousFTPClient extends FTPClient {
         }
     }
 
-    public void navigateToDirectory(String directory) throws IOException {
-        if (!super.changeWorkingDirectory(directory)) {
-            throw new RuntimeException("Unable to change to directory '" + directory + "'");
-        }
-    }
-
 }

--- a/src/main/java/com/ebivariation/contigalias/dus/PassiveAnonymousFTPClient.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/PassiveAnonymousFTPClient.java
@@ -17,88 +17,66 @@
 package com.ebivariation.contigalias.dus;
 
 import org.apache.commons.net.ftp.FTPClient;
-import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPReply;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
 
-public class FTPBrowser {
+public class PassiveAnonymousFTPClient extends FTPClient {
 
     private static final int DEFAULT_FTP_PORT = 21;
 
-    private final Logger logger = LoggerFactory.getLogger(FTPBrowser.class);
-
-    private final FTPClient ftp = new FTPClient();
+    private final Logger logger = LoggerFactory.getLogger(PassiveAnonymousFTPClient.class);
 
     public void connect(String address) throws IOException {
-        connect(address, DEFAULT_FTP_PORT);
+        this.connect(address, DEFAULT_FTP_PORT);
     }
 
+    @Override
     public void connect(String address, int port) throws IOException {
 
         try {
-            ftp.connect(address, port);
+            super.connect(address, port);
             // After connection attempt, you should check the reply code to verify
             // success.
-            int reply = ftp.getReplyCode();
+            int reply = super.getReplyCode();
             logger.debug("Connected to {} with reply code {}.", address, reply);
             if (!FTPReply.isPositiveCompletion(reply)) {
                 throw new RuntimeException("FTP refused connection");
             }
 
             // Login as anonymous user
-            ftp.enterLocalPassiveMode();
-            boolean login = ftp.login("anonymous", "anonymous");
+            super.enterLocalPassiveMode();
+            boolean login = super.login("anonymous", "anonymous");
             logger.debug("Login {}.", (login ? "successful" : "unsuccessful"));
             if (!login) {
                 throw new RuntimeException("FTP refused login");
             }
 
-            String status = ftp.getStatus();
+            String status = super.getStatus();
             logger.debug("FTP connection status: {}", status);
             logger.info("Connected successfully to {}", address);
         } catch (Exception e) {
             logger.error("Could not connect to FTP server '{}'. FTP status was: {}. Reply code: {}. Reply string: {}",
-                         address, ftp.getStatus(), ftp.getReply(), ftp.getReplyString());
-            ftp.disconnect();
+                         address, super.getStatus(), super.getReply(), super.getReplyString());
+            this.disconnect();
             throw e;
         }
     }
 
+    @Override
     public void disconnect() throws IOException {
-        if (ftp.isConnected()) {
-            ftp.logout();
-            ftp.disconnect();
+        if (super.isConnected()) {
+            super.logout();
+            super.disconnect();
         }
-    }
-
-    public FTPFile[] listFiles() throws IOException {
-        return ftp.listFiles();
-    }
-
-    public FTPFile[] listFiles(String path) throws IOException{
-        return ftp.listFiles(path);
-    }
-
-    public FTPFile[] listDirectories() throws IOException {
-        return ftp.listDirectories();
-    }
-
-    public FTPFile[] listDirectories(String path) throws IOException {
-        return ftp.listDirectories(path);
     }
 
     public void navigateToDirectory(String directory) throws IOException {
-        if (!ftp.changeWorkingDirectory(directory)) {
+        if (!super.changeWorkingDirectory(directory)) {
             throw new RuntimeException("Unable to change to directory '" + directory + "'");
         }
-    }
-
-    public InputStream retrieveFileStream(String filePath) throws IOException {
-        return ftp.retrieveFileStream(filePath);
     }
 
 }

--- a/src/test/java/com/ebivariation/contigalias/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/NCBIBrowserTest.java
@@ -49,8 +49,7 @@ public class NCBIBrowserTest {
 
     @Test
     void navigateToAllGenomesDirectory() throws IOException {
-        boolean b = ncbiBrowser.changeWorkingDirectoryToGenomesAll();
-        assertTrue(b);
+        assertTrue(ncbiBrowser.changeWorkingDirectoryToGenomesAll());
         assertTrue(ncbiBrowser.listFiles().length > 0);
     }
 

--- a/src/test/java/com/ebivariation/contigalias/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/NCBIBrowserTest.java
@@ -49,13 +49,14 @@ public class NCBIBrowserTest {
 
     @Test
     void navigateToAllGenomesDirectory() throws IOException {
-        ncbiBrowser.navigateToAllGenomesDirectory();
+        boolean b = ncbiBrowser.changeWorkingDirectoryToGenomesAll();
+        assertTrue(b);
         assertTrue(ncbiBrowser.listFiles().length > 0);
     }
 
     @Test
     void navigateToSubDirectoryPath() throws IOException {
-        ncbiBrowser.navigateToSubDirectoryPath("/genomes/INFLUENZA/");
+        ncbiBrowser.changeWorkingDirectory("/genomes/INFLUENZA/");
         assertTrue(ncbiBrowser.listFiles().length > 0);
     }
 

--- a/src/test/java/com/ebivariation/contigalias/PassiveAnonymousFTPClientTest.java
+++ b/src/test/java/com/ebivariation/contigalias/PassiveAnonymousFTPClientTest.java
@@ -16,7 +16,7 @@
 
 package com.ebivariation.contigalias;
 
-import com.ebivariation.contigalias.dus.FTPBrowser;
+import com.ebivariation.contigalias.dus.PassiveAnonymousFTPClient;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.junit.jupiter.api.AfterEach;
@@ -30,42 +30,42 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FTPBrowserTest {
+public class PassiveAnonymousFTPClientTest {
 
     private static final String SERVER_NCBI = "ftp.ncbi.nlm.nih.gov";
 
     @Nested
     class WithSetupAndTeardown {
 
-        private FTPBrowser ftpBrowser;
+        private PassiveAnonymousFTPClient ftpClient;
 
         @BeforeEach
         void setUp() throws IOException {
-            ftpBrowser = new FTPBrowser();
-            ftpBrowser.connect(SERVER_NCBI);
+            ftpClient = new PassiveAnonymousFTPClient();
+            ftpClient.connect(SERVER_NCBI);
         }
 
         @AfterEach
         void tearDown() throws IOException {
-            ftpBrowser.disconnect();
+            ftpClient.disconnect();
         }
 
         @Test
         void changeDirectory() throws IOException {
-            ftpBrowser.navigateToDirectory("genomes");
+            ftpClient.navigateToDirectory("genomes");
         }
 
         @Test
         void changeDirectoryAndList() throws IOException {
-            ftpBrowser.navigateToDirectory("genomes");
-            FTPFile[] ftpFiles = ftpBrowser.listFiles();
+            ftpClient.navigateToDirectory("genomes");
+            FTPFile[] ftpFiles = ftpClient.listFiles();
             assertTrue(ftpFiles.length > 0);
         }
 
         @Test
         void changeToNestedDirectoryAndFindAssemblyReport() throws IOException {
-            ftpBrowser.navigateToDirectory("genomes/all/GCA/000/002/305/GCA_000002305.1_EquCab2.0/");
-            FTPFile[] ftpFiles = ftpBrowser.listFiles();
+            ftpClient.navigateToDirectory("genomes/all/GCA/000/002/305/GCA_000002305.1_EquCab2.0/");
+            FTPFile[] ftpFiles = ftpClient.listFiles();
             assertTrue(ftpFiles.length > 0);
             String assemblyReport = "GCA_000002305.1_EquCab2.0_assembly_report.txt";
             boolean found = Stream.of(ftpFiles)
@@ -76,7 +76,7 @@ public class FTPBrowserTest {
 
         @Test
         void listDirectories() throws IOException {
-            FTPFile[] ftpFiles = ftpBrowser.listDirectories();
+            FTPFile[] ftpFiles = ftpClient.listDirectories();
             assertTrue(ftpFiles.length > 0);
         }
 
@@ -89,13 +89,13 @@ public class FTPBrowserTest {
 
         @Test
         void connectToServerWithExplicitPort() throws IOException {
-            FTPBrowser ftpBrowser = new FTPBrowser();
+            PassiveAnonymousFTPClient passiveAnonymousFtpClient = new PassiveAnonymousFTPClient();
             try {
-                ftpBrowser.connect(SERVER_NCBI, PORT_NCBI_FTP);
-                FTPFile[] ftpFiles = ftpBrowser.listFiles();
+                passiveAnonymousFtpClient.connect(SERVER_NCBI, PORT_NCBI_FTP);
+                FTPFile[] ftpFiles = passiveAnonymousFtpClient.listFiles();
                 assertTrue(ftpFiles.length > 0);
             } finally {
-                ftpBrowser.disconnect();
+                passiveAnonymousFtpClient.disconnect();
             }
         }
 

--- a/src/test/java/com/ebivariation/contigalias/PassiveAnonymousFTPClientTest.java
+++ b/src/test/java/com/ebivariation/contigalias/PassiveAnonymousFTPClientTest.java
@@ -52,19 +52,19 @@ public class PassiveAnonymousFTPClientTest {
 
         @Test
         void changeDirectory() throws IOException {
-            ftpClient.navigateToDirectory("genomes");
+            ftpClient.changeWorkingDirectory("genomes");
         }
 
         @Test
         void changeDirectoryAndList() throws IOException {
-            ftpClient.navigateToDirectory("genomes");
+            ftpClient.changeWorkingDirectory("genomes");
             FTPFile[] ftpFiles = ftpClient.listFiles();
             assertTrue(ftpFiles.length > 0);
         }
 
         @Test
         void changeToNestedDirectoryAndFindAssemblyReport() throws IOException {
-            ftpClient.navigateToDirectory("genomes/all/GCA/000/002/305/GCA_000002305.1_EquCab2.0/");
+            ftpClient.changeWorkingDirectory("genomes/all/GCA/000/002/305/GCA_000002305.1_EquCab2.0/");
             FTPFile[] ftpFiles = ftpClient.listFiles();
             assertTrue(ftpFiles.length > 0);
             String assemblyReport = "GCA_000002305.1_EquCab2.0_assembly_report.txt";


### PR DESCRIPTION
While working on a new feature I realized that FTPBrowser has a lot of methods that simply called their respective super methods and FTPBrowser itself doesn't add a lot of functionality to FTPClient.
Thus it is better for FTPBrowser to extend FTPClient rather than use it.
FTPBrowser only logs in as an anonymous user and puts the connection in "local passive" mode.
Thus I have renamed the class to PassiveAnonymousFTPClient.
This will remove boilerplate methods that have to maintained + tested and inheritance is better OOP practice.