### PR TITLE
Client API to access assembly though accession

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
 			<scope>runtime</scope>
 			<version>1.4.199</version>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
+++ b/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 
-@RequestMapping("contig-alias/api")
+@RequestMapping("contig-alias")
 @RestController
 public class ClientAPI {
 
@@ -37,7 +37,7 @@ public class ClientAPI {
         this.service = service;
     }
 
-    @GetMapping(value = "{accession}")
+    @GetMapping(value = "assemblies/{accession}")
     public AssemblyEntity getAssemblyByAccession(@PathVariable String accession) throws IOException {
         AssemblyEntity assemblyByAccession = service.getAssemblyByAccession(accession);
         return assemblyByAccession;

--- a/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
+++ b/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
@@ -19,15 +19,15 @@ package com.ebivariation.contigalias.api;
 import com.ebivariation.contigalias.entities.AssemblyEntity;
 import com.ebivariation.contigalias.service.AssemblyService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 
 @RequestMapping("contig-alias/api")
-@Controller
+@RestController
 public class ClientAPI {
 
     private final AssemblyService service;
@@ -39,7 +39,8 @@ public class ClientAPI {
 
     @GetMapping(value = "{accession}")
     public AssemblyEntity getAssemblyByAccession(@PathVariable String accession) throws IOException {
-        return service.getAssemblyByAccession(accession);
+        AssemblyEntity assemblyByAccession = service.getAssemblyByAccession(accession);
+        return assemblyByAccession;
     }
 
 }

--- a/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
+++ b/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @RequestMapping("contig-alias")
 @RestController
@@ -38,9 +39,8 @@ public class ClientAPI {
     }
 
     @GetMapping(value = "assemblies/{accession}")
-    public AssemblyEntity getAssemblyByAccession(@PathVariable String accession) throws IOException {
-        AssemblyEntity assemblyByAccession = service.getAssemblyByAccession(accession);
-        return assemblyByAccession;
+    public Optional<AssemblyEntity> getAssemblyByAccession(@PathVariable String accession) throws IOException {
+        return service.getAssemblyByAccession(accession);
     }
 
 }

--- a/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
+++ b/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
@@ -22,9 +22,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 @RequestMapping("contig-alias")
@@ -41,6 +43,15 @@ public class ClientAPI {
     @GetMapping(value = "assemblies/{accession}")
     public Optional<AssemblyEntity> getAssemblyByAccession(@PathVariable String accession) throws IOException {
         return service.getAssemblyByAccession(accession);
+    }
+
+    @GetMapping(value = "assemblies")
+    public Optional<List<AssemblyEntity>> getAssembliesQuery(
+            @RequestParam Optional<String> name,
+            @RequestParam Optional<Long> taxid,
+            @RequestParam Optional<String> genbank,
+            @RequestParam Optional<String> refseq) {
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
+++ b/src/main/java/com/ebivariation/contigalias/api/ClientAPI.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ebivariation.contigalias.api;
+
+import com.ebivariation.contigalias.entities.AssemblyEntity;
+import com.ebivariation.contigalias.service.AssemblyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.io.IOException;
+
+@RequestMapping("contig-alias/api")
+@Controller
+public class ClientAPI {
+
+    private final AssemblyService service;
+
+    @Autowired
+    public ClientAPI(AssemblyService service) {
+        this.service = service;
+    }
+
+    @GetMapping(value = "{accession}")
+    public AssemblyEntity getAssemblyByAccession(@PathVariable String accession) throws IOException {
+        return service.getAssemblyByAccession(accession);
+    }
+
+}

--- a/src/main/java/com/ebivariation/contigalias/api/ContigAliasController.java
+++ b/src/main/java/com/ebivariation/contigalias/api/ContigAliasController.java
@@ -31,12 +31,12 @@ import java.util.Optional;
 
 @RequestMapping("contig-alias")
 @RestController
-public class ClientAPI {
+public class ContigAliasController {
 
     private final AssemblyService service;
 
     @Autowired
-    public ClientAPI(AssemblyService service) {
+    public ContigAliasController(AssemblyService service) {
         this.service = service;
     }
 

--- a/src/main/java/com/ebivariation/contigalias/dao/AssemblyDao.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/AssemblyDao.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ebivariation.contigalias.dao;
+
+import com.ebivariation.contigalias.entities.AssemblyEntity;
+
+import java.io.IOException;
+
+public interface AssemblyDao {
+
+    AssemblyEntity getAssemblyByAccession(String accession) throws IOException;
+
+}

--- a/src/main/java/com/ebivariation/contigalias/dao/AssemblyDao.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/AssemblyDao.java
@@ -19,9 +19,10 @@ package com.ebivariation.contigalias.dao;
 import com.ebivariation.contigalias.entities.AssemblyEntity;
 
 import java.io.IOException;
+import java.util.Optional;
 
 public interface AssemblyDao {
 
-    AssemblyEntity getAssemblyByAccession(String accession) throws IOException;
+    Optional<AssemblyEntity> getAssemblyByAccession(String accession) throws IOException;
 
 }

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -36,13 +36,15 @@ public class FTPClientAssemblyDaoImplement implements AssemblyDao {
         NCBIBrowser ncbiBrowser = new NCBIBrowser();
         ncbiBrowser.connect();
         String directory = ncbiBrowser.getGenomeReportDirectory(accession);
-        InputStream stream = ncbiBrowser.getAssemblyReportInputStream(PATH_GENOMES_ALL + directory);
-        InputStreamReader streamReader = new InputStreamReader(stream);
-        AssemblyReportReader reader = new AssemblyReportReader(streamReader);
-        AssemblyEntity assemblyEntity = reader.getAssemblyEntity();
-        stream.close();
-        streamReader.close();
-        ncbiBrowser.disconnect();
+        AssemblyEntity assemblyEntity;
+        try (InputStream stream = ncbiBrowser.getAssemblyReportInputStream(PATH_GENOMES_ALL + directory)) {
+            InputStreamReader streamReader = new InputStreamReader(stream);
+            AssemblyReportReader reader = new AssemblyReportReader(streamReader);
+            assemblyEntity = reader.getAssemblyEntity();
+            streamReader.close();
+        }finally {
+            ncbiBrowser.disconnect();
+        }
         return Optional.of(assemblyEntity);
     }
 

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
-import static com.ebivariation.contigalias.dus.NCBIBrowser.PATH_GENOMES_ALL;
-
 @Repository("ftpDao")
 public class FTPClientAssemblyDaoImplement implements AssemblyDao {
 
@@ -39,7 +37,7 @@ public class FTPClientAssemblyDaoImplement implements AssemblyDao {
             return Optional.empty();
         }
         AssemblyEntity assemblyEntity;
-        try (InputStream stream = ncbiBrowser.getAssemblyReportInputStream(PATH_GENOMES_ALL + directory)) {
+        try (InputStream stream = ncbiBrowser.getAssemblyReportInputStream(directory.get())) {
             AssemblyReportReader reader = new AssemblyReportReader(stream);
             assemblyEntity = reader.getAssemblyEntity();
         } finally {

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Repository;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Optional;
 
 import static com.ebivariation.contigalias.dus.NCBIBrowser.PATH_GENOMES_ALL;
 
@@ -31,7 +32,7 @@ import static com.ebivariation.contigalias.dus.NCBIBrowser.PATH_GENOMES_ALL;
 public class FTPClientAssemblyDaoImplement implements AssemblyDao {
 
     @Override
-    public AssemblyEntity getAssemblyByAccession(String accession) throws IOException {
+    public Optional<AssemblyEntity> getAssemblyByAccession(String accession) throws IOException {
         NCBIBrowser ncbiBrowser = new NCBIBrowser();
         ncbiBrowser.connect();
         String directory = ncbiBrowser.getGenomeReportDirectory(accession);
@@ -42,7 +43,7 @@ public class FTPClientAssemblyDaoImplement implements AssemblyDao {
         stream.close();
         streamReader.close();
         ncbiBrowser.disconnect();
-        return assemblyEntity;
+        return Optional.of(assemblyEntity);
     }
 
 }

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -34,7 +34,9 @@ public class FTPClientAssemblyDaoImplement implements AssemblyDao {
         ncbiBrowser.connect();
         ncbiBrowser.navigateToAllGenomesDirectory();
         String directory = ncbiBrowser.getGenomeReportDirectory(accession);
-        InputStream stream = ncbiBrowser.getAssemblyReportInputStream(directory);
+        ncbiBrowser.navigateToSubDirectoryPath(directory);
+        String path = ncbiBrowser.getAbsolutePath(directory);
+        InputStream stream = ncbiBrowser.getAssemblyReportInputStream(path);
         InputStreamReader streamReader = new InputStreamReader(stream);
         AssemblyReportReader reader = new AssemblyReportReader(streamReader);
         AssemblyEntity assemblyEntity = reader.getAssemblyEntity();

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import static com.ebivariation.contigalias.dus.NCBIBrowser.PATH_GENOMES_ALL;
+
 @Repository("ftpDao")
 public class FTPClientAssemblyDaoImplement implements AssemblyDao {
 
@@ -33,8 +35,7 @@ public class FTPClientAssemblyDaoImplement implements AssemblyDao {
         NCBIBrowser ncbiBrowser = new NCBIBrowser();
         ncbiBrowser.connect();
         String directory = ncbiBrowser.getGenomeReportDirectory(accession);
-        String path = ncbiBrowser.getPathFromRoot(directory);
-        InputStream stream = ncbiBrowser.getAssemblyReportInputStream(path);
+        InputStream stream = ncbiBrowser.getAssemblyReportInputStream(PATH_GENOMES_ALL + directory);
         InputStreamReader streamReader = new InputStreamReader(stream);
         AssemblyReportReader reader = new AssemblyReportReader(streamReader);
         AssemblyEntity assemblyEntity = reader.getAssemblyEntity();

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ebivariation.contigalias.dao;
+
+import com.ebivariation.contigalias.dus.AssemblyReportReader;
+import com.ebivariation.contigalias.dus.NCBIBrowser;
+import com.ebivariation.contigalias.entities.AssemblyEntity;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+@Repository("ftpDao")
+public class FTPClientAssemblyDaoImplement implements AssemblyDao {
+
+    @Override
+    public AssemblyEntity getAssemblyByAccession(String accession) throws IOException {
+        NCBIBrowser ncbiBrowser = new NCBIBrowser();
+        ncbiBrowser.connect();
+        ncbiBrowser.navigateToAllGenomesDirectory();
+        String directory = ncbiBrowser.getGenomeReportDirectory(accession);
+        InputStream stream = ncbiBrowser.getAssemblyReportInputStream(directory);
+        InputStreamReader streamReader = new InputStreamReader(stream);
+        AssemblyReportReader reader = new AssemblyReportReader(streamReader);
+        AssemblyEntity assemblyEntity = reader.getAssemblyEntity();
+        stream.close();
+        streamReader.close();
+        ncbiBrowser.disconnect();
+        return assemblyEntity;
+    }
+
+}

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -32,10 +32,8 @@ public class FTPClientAssemblyDaoImplement implements AssemblyDao {
     public AssemblyEntity getAssemblyByAccession(String accession) throws IOException {
         NCBIBrowser ncbiBrowser = new NCBIBrowser();
         ncbiBrowser.connect();
-        ncbiBrowser.navigateToAllGenomesDirectory();
         String directory = ncbiBrowser.getGenomeReportDirectory(accession);
-        ncbiBrowser.navigateToSubDirectoryPath(directory);
-        String path = ncbiBrowser.getAbsolutePath(directory);
+        String path = ncbiBrowser.getPathFromRoot(directory);
         InputStream stream = ncbiBrowser.getAssemblyReportInputStream(path);
         InputStreamReader streamReader = new InputStreamReader(stream);
         AssemblyReportReader reader = new AssemblyReportReader(streamReader);

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Repository;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Optional;
 
 import static com.ebivariation.contigalias.dus.NCBIBrowser.PATH_GENOMES_ALL;
@@ -41,10 +40,8 @@ public class FTPClientAssemblyDaoImplement implements AssemblyDao {
         }
         AssemblyEntity assemblyEntity;
         try (InputStream stream = ncbiBrowser.getAssemblyReportInputStream(PATH_GENOMES_ALL + directory)) {
-            InputStreamReader streamReader = new InputStreamReader(stream);
-            AssemblyReportReader reader = new AssemblyReportReader(streamReader);
+            AssemblyReportReader reader = new AssemblyReportReader(stream);
             assemblyEntity = reader.getAssemblyEntity();
-            streamReader.close();
         } finally {
             ncbiBrowser.disconnect();
         }

--- a/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
+++ b/src/main/java/com/ebivariation/contigalias/dao/FTPClientAssemblyDaoImplement.java
@@ -35,14 +35,17 @@ public class FTPClientAssemblyDaoImplement implements AssemblyDao {
     public Optional<AssemblyEntity> getAssemblyByAccession(String accession) throws IOException {
         NCBIBrowser ncbiBrowser = new NCBIBrowser();
         ncbiBrowser.connect();
-        String directory = ncbiBrowser.getGenomeReportDirectory(accession);
+        Optional<String> directory = ncbiBrowser.getGenomeReportDirectory(accession);
+        if (directory.isEmpty()) {
+            return Optional.empty();
+        }
         AssemblyEntity assemblyEntity;
         try (InputStream stream = ncbiBrowser.getAssemblyReportInputStream(PATH_GENOMES_ALL + directory)) {
             InputStreamReader streamReader = new InputStreamReader(stream);
             AssemblyReportReader reader = new AssemblyReportReader(streamReader);
             assemblyEntity = reader.getAssemblyEntity();
             streamReader.close();
-        }finally {
+        } finally {
             ncbiBrowser.disconnect();
         }
         return Optional.of(assemblyEntity);

--- a/src/main/java/com/ebivariation/contigalias/dus/AssemblyReportReader.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/AssemblyReportReader.java
@@ -21,6 +21,7 @@ import com.ebivariation.contigalias.entities.ChromosomeEntity;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.LinkedList;
 import java.util.List;
@@ -37,10 +38,15 @@ public class AssemblyReportReader {
         reader = new BufferedReader(inputStreamReader);
     }
 
+    public AssemblyReportReader(InputStream inputStream) {
+        reader = new BufferedReader(new InputStreamReader(inputStream));
+    }
+
     /**
      * Returns the class-level instance variable of {@link AssemblyEntity}. If the variable has not been initialized
      * or the assembly report has not been parsed yet, it calls {@link #parseReport()} and then returns the variable
      * that would have been initialized by {@link #parseReport()}.
+     *
      * @return {@link AssemblyEntity} containing all metadata extracted from the report along with a list of
      * {@link ChromosomeEntity} which also contain their own metadata.
      * @throws IOException Passes IOException thrown by {@link #parseReport()}
@@ -54,6 +60,7 @@ public class AssemblyReportReader {
 
     /**
      * Reads the report line-by-line and calls the relevant methods to parse each line based on its starting characters.
+     *
      * @throws IOException Passes IOException thrown by {@link BufferedReader#readLine()}
      */
     private void parseReport() throws IOException {
@@ -75,6 +82,7 @@ public class AssemblyReportReader {
     /**
      * Parses lines in assembly report containing Assembly metadata. Breaks line into a tag:tagData format and
      * sets tagData in {@link AssemblyEntity} fields corresponding to the tag found in given line.
+     *
      * @param line A line of assembly report file starting with "# ".
      */
     private void parseAssemblyData(String line) {
@@ -116,6 +124,7 @@ public class AssemblyReportReader {
      * Parses lines in assembly report containing Chromosome metadata. Splits line into an array of fields using
      * {@link String#split(String)} with "\t" as the separator. This array is used to set metadata to corresponding
      * fields in {@link ChromosomeEntity}.
+     *
      * @param line A line of assembly report file not starting with "#".
      */
     private void parseChromosomeLine(String line) {

--- a/src/main/java/com/ebivariation/contigalias/dus/AssemblyReportReader.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/AssemblyReportReader.java
@@ -77,6 +77,7 @@ public class AssemblyReportReader {
             line = reader.readLine();
         }
         reportParsed = true;
+        reader.close();
     }
 
     /**

--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -74,18 +74,20 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
         FTPFile[] ftpFiles = super.listDirectories(currPath);
 
         if (ftpFiles.length > 0) {
-            String dirName = ftpFiles[0].getName();
-            if (dirName.contains(rawQuery)) {
+            Optional<FTPFile> dir = Arrays.stream(ftpFiles).filter(it -> it.getName().contains(rawQuery)).findFirst();
+            if (dir.isPresent()) {
                 // path = "GCA/004/051/055/GCA_004051055.1_ASM405105v1/"
-                path += dirName + "/";
+                path += dir.get().getName() + "/";
+                return path;
             }
-        } else path = null;
+        }
 
-        return path;
+        return null;
+
     }
 
-    public String getAbsolutePath(String relativePath){
-        return NCBI_FTP_SERVER + PATH_GENOMES_ALL + relativePath;
+    public String getPathFromRoot(String relativePath) {
+        return PATH_GENOMES_ALL + relativePath;
     }
 
     /**
@@ -99,7 +101,8 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
         InputStream fileStream;
 
         Stream<FTPFile> ftpFileStream = Arrays.stream(super.listFiles(directoryPath));
-        Stream<FTPFile> assemblyReportFilteredStream = ftpFileStream.filter(f -> f.getName().contains("assembly_report.txt"));
+        Stream<FTPFile> assemblyReportFilteredStream = ftpFileStream.filter(
+                f -> f.getName().contains("assembly_report.txt"));
         Optional<FTPFile> assemblyReport = assemblyReportFilteredStream.findFirst();
 
         if (assemblyReport.isPresent()) {

--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -36,10 +36,11 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
 
     /**
      * Takes a Genbank or Refseq accession and converts it to the equivalent path used by NCBI's FTP server.
-     * For example, on input "GCF_007608995.1" the output path is "GCF/007/608/995/GCF_007608995.1_ASM760899v1/".
+     * For example, on input "GCF_007608995.1" the output path is "/genomes/all/GCF/007/608/995/GCF_007608995
+     * .1_ASM760899v1/".
      *
      * @param accession Any GCA or GCF String
-     * @return Path relative to ftp.ncbi.nlm.nih.gov/genomes/all/
+     * @return Path relative to ftp.ncbi.nlm.nih.gov
      * @throws IOException Passes exception thrown by FTPBrowser.listDirectories()
      */
     public Optional<String> getGenomeReportDirectory(String accession) throws IOException {
@@ -74,7 +75,7 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
             if (dir.isPresent()) {
                 // path = "GCA/004/051/055/GCA_004051055.1_ASM405105v1/"
                 path += dir.get().getName() + "/";
-                return Optional.of(path);
+                return Optional.of(PATH_GENOMES_ALL + path);
             }
         }
 

--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -86,10 +86,6 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
 
     }
 
-    public String getPathFromRoot(String relativePath) {
-        return PATH_GENOMES_ALL + relativePath;
-    }
-
     /**
      * @param directoryPath The path of the directory in which target report is located relative to root of FTP server.
      *                      Eg:- "/genomes/all/GCF/007/608/995/GCF_007608995.1_ASM760899v1/"

--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -84,6 +84,10 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
         return path;
     }
 
+    public String getAbsolutePath(String relativePath){
+        return NCBI_FTP_SERVER + PATH_GENOMES_ALL + relativePath;
+    }
+
     /**
      * @param directoryPath The path of the directory in which target report is located relative to root of FTP server.
      *                      Eg:- "/genomes/all/GCF/007/608/995/GCF_007608995.1_ASM760899v1/"

--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -42,7 +42,7 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
      * @return Path relative to ftp.ncbi.nlm.nih.gov/genomes/all/
      * @throws IOException Passes exception thrown by FTPBrowser.listDirectories()
      */
-    public String getGenomeReportDirectory(String accession) throws IOException {
+    public Optional<String> getGenomeReportDirectory(String accession) throws IOException {
 
         //GCA_004051055.1
         String rawQuery = accession;
@@ -74,11 +74,11 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
             if (dir.isPresent()) {
                 // path = "GCA/004/051/055/GCA_004051055.1_ASM405105v1/"
                 path += dir.get().getName() + "/";
-                return path;
+                return Optional.of(path);
             }
         }
 
-        return null;
+        return Optional.empty();
 
     }
 

--- a/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
+++ b/src/main/java/com/ebivariation/contigalias/dus/NCBIBrowser.java
@@ -34,10 +34,6 @@ public class NCBIBrowser extends PassiveAnonymousFTPClient {
         super.connect(NCBI_FTP_SERVER);
     }
 
-    public boolean changeWorkingDirectoryToGenomesAll() throws IOException {
-        return super.changeWorkingDirectory(PATH_GENOMES_ALL);
-    }
-
     /**
      * Takes a Genbank or Refseq accession and converts it to the equivalent path used by NCBI's FTP server.
      * For example, on input "GCF_007608995.1" the output path is "GCF/007/608/995/GCF_007608995.1_ASM760899v1/".

--- a/src/main/java/com/ebivariation/contigalias/service/AssemblyService.java
+++ b/src/main/java/com/ebivariation/contigalias/service/AssemblyService.java
@@ -35,7 +35,9 @@ public class AssemblyService {
     }
 
     public AssemblyEntity getAssemblyByAccession(String accession) throws IOException {
-        return assemblyDao.getAssemblyByAccession(accession);
+        AssemblyEntity assembly = assemblyDao.getAssemblyByAccession(accession);
+        assembly.getChromosomes().forEach(it -> it.setAssembly(null));
+        return assembly;
     }
 
 }

--- a/src/main/java/com/ebivariation/contigalias/service/AssemblyService.java
+++ b/src/main/java/com/ebivariation/contigalias/service/AssemblyService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ebivariation.contigalias.service;
+
+import com.ebivariation.contigalias.dao.AssemblyDao;
+import com.ebivariation.contigalias.entities.AssemblyEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+public class AssemblyService {
+
+    private final AssemblyDao assemblyDao;
+
+    @Autowired
+    public AssemblyService(@Qualifier("ftpDao") AssemblyDao assemblyDao) {
+        this.assemblyDao = assemblyDao;
+    }
+
+    public AssemblyEntity getAssemblyByAccession(String accession) throws IOException {
+        return assemblyDao.getAssemblyByAccession(accession);
+    }
+
+}

--- a/src/main/java/com/ebivariation/contigalias/service/AssemblyService.java
+++ b/src/main/java/com/ebivariation/contigalias/service/AssemblyService.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Service
 public class AssemblyService {
@@ -34,9 +35,9 @@ public class AssemblyService {
         this.assemblyDao = assemblyDao;
     }
 
-    public AssemblyEntity getAssemblyByAccession(String accession) throws IOException {
-        AssemblyEntity assembly = assemblyDao.getAssemblyByAccession(accession);
-        assembly.getChromosomes().forEach(it -> it.setAssembly(null));
+    public Optional<AssemblyEntity> getAssemblyByAccession(String accession) throws IOException {
+        Optional<AssemblyEntity> assembly = assemblyDao.getAssemblyByAccession(accession);
+        assembly.ifPresent(asm -> asm.getChromosomes().forEach(chr -> chr.setAssembly(null)));
         return assembly;
     }
 

--- a/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
@@ -50,7 +50,7 @@ public class NCBIBrowserTest {
 
     @Test
     void navigateToAllGenomesDirectory() throws IOException {
-        assertTrue(ncbiBrowser.changeWorkingDirectoryToGenomesAll());
+        assertTrue(ncbiBrowser.changeWorkingDirectory(PATH_GENOMES_ALL));
         assertTrue(ncbiBrowser.listFiles().length > 0);
     }
 

--- a/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
@@ -16,7 +16,6 @@
 
 package com.ebivariation.contigalias.dus;
 
-import com.ebivariation.contigalias.dus.NCBIBrowser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
@@ -64,14 +64,14 @@ public class NCBIBrowserTest {
     void getGenomeReportDirectoryGCATest() throws IOException {
         Optional<String> path = ncbiBrowser.getGenomeReportDirectory("GCA_004051055.1");
         assertTrue(path.isPresent());
-        assertEquals("GCA/004/051/055/GCA_004051055.1_ASM405105v1/", path.get());
+        assertEquals("/genomes/all/GCA/004/051/055/GCA_004051055.1_ASM405105v1/", path.get());
     }
 
     @Test
     void getGenomeReportDirectoryGCFTest() throws IOException {
         Optional<String> path = ncbiBrowser.getGenomeReportDirectory("GCF_007608995.1");
         assertTrue(path.isPresent());
-        assertEquals("GCF/007/608/995/GCF_007608995.1_ASM760899v1/", path.get());
+        assertEquals("/genomes/all/GCF/007/608/995/GCF_007608995.1_ASM760899v1/", path.get());
     }
 
     @Test

--- a/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.ebivariation.contigalias;
+package com.ebivariation.contigalias.dus;
 
 import com.ebivariation.contigalias.dus.NCBIBrowser;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 import static com.ebivariation.contigalias.dus.NCBIBrowser.PATH_GENOMES_ALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,14 +62,16 @@ public class NCBIBrowserTest {
 
     @Test
     void getGenomeReportDirectoryGCATest() throws IOException {
-        String path = ncbiBrowser.getGenomeReportDirectory("GCA_004051055.1");
-        assertEquals("GCA/004/051/055/GCA_004051055.1_ASM405105v1/", path);
+        Optional<String> path = ncbiBrowser.getGenomeReportDirectory("GCA_004051055.1");
+        assertTrue(path.isPresent());
+        assertEquals("GCA/004/051/055/GCA_004051055.1_ASM405105v1/", path.get());
     }
 
     @Test
     void getGenomeReportDirectoryGCFTest() throws IOException {
-        String path = ncbiBrowser.getGenomeReportDirectory("GCF_007608995.1");
-        assertEquals("GCF/007/608/995/GCF_007608995.1_ASM760899v1/", path);
+        Optional<String> path = ncbiBrowser.getGenomeReportDirectory("GCF_007608995.1");
+        assertTrue(path.isPresent());
+        assertEquals("GCF/007/608/995/GCF_007608995.1_ASM760899v1/", path.get());
     }
 
     @Test

--- a/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
+++ b/src/test/java/com/ebivariation/contigalias/dus/NCBIBrowserTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static com.ebivariation.contigalias.dus.NCBIBrowser.PATH_GENOMES_ALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -72,12 +73,9 @@ public class NCBIBrowserTest {
 
     @Test
     void getAssemblyReportInputStream() throws IOException {
-        InputStream stream = ncbiBrowser.getAssemblyReportInputStream(
-                "/genomes/all/GCF/007/608/995/GCF_007608995.1_ASM760899v1/");
-        try {
+        try (InputStream stream = ncbiBrowser.getAssemblyReportInputStream(
+                "/genomes/all/GCF/007/608/995/GCF_007608995.1_ASM760899v1/")) {
             assertTrue(stream.read() != -1);
-        } finally {
-            stream.close();
         }
     }
 }

--- a/src/test/java/com/ebivariation/contigalias/dus/PassiveAnonymousFTPClientTest.java
+++ b/src/test/java/com/ebivariation/contigalias/dus/PassiveAnonymousFTPClientTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.ebivariation.contigalias;
+package com.ebivariation.contigalias.dus;
 
-import com.ebivariation.contigalias.dus.PassiveAnonymousFTPClient;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
I created a few classes to expose an API endpoint and was able to get an assembly with its chromosomes as a JSON response.

## Changes ##

- New dependency added in pom.xml to use HTTP mappings in controller
- Client API to get assembly at `http://{serverIP}:8080/contig-alias/api/{accession}`
- AssemblyDao interface
- FTPClientAssemblyDaoImplement to provide no persistence implementation of AssemblyDao
- NCBIBrowser#getGenomeReportDirectory(String accession) -- fix an issue where a directory having more than one subdirectory may result in nothing getting appeneded to path
- AssemblyService to implement functionality in API

Disregard any changes already proposed in PR #10.