### PR TITLE
Fixes #36 -- Changed harcoded base package in SwaggerConfig to "uk.ac.ebi.eva.contigalias.controller"

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/swagger/SwaggerConfig.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/swagger/SwaggerConfig.java
@@ -42,7 +42,7 @@ public class SwaggerConfig implements WebMvcConfigurer {
         return new Docket(DocumentationType.SWAGGER_2)
                 .apiInfo(getApiInfo())
                 .select()
-                .apis(RequestHandlerSelectors.basePackage("com.ebivariation.contigalias.controller"))
+                .apis(RequestHandlerSelectors.basePackage("uk.ac.ebi.eva.contigalias.controller"))
                 .paths(PathSelectors.any())
                 .build();
     }


### PR DESCRIPTION
The base package has to be hard-coded as a String and didn't get renamed when the project's package was renamed. This discrepancy between this and the actual package name lead to Swagger breaking and displaying a "No operations defined in spec!" message on the Swagger UI page.