### PR TITLE
Security fixes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ package-production:
     script:
         - DATETIME=$(date +%Y-%m-%dT%H-%M-%S)
         - apk add --update curl
-        - curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T "$WS_ARTIFACT_PATH" "http://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva/webservices/contig-alias&version=$DATETIME" | grep "OK - Deployed application"
+        - curl -u $TOMCAT_USER:$TOMCAT_PASSWORD -T "$WS_ARTIFACT_PATH" "https://$TOMCAT_HOST/manager/text/deploy?update=true&path=/eva/webservices/contig-alias&version=$DATETIME" | grep "OK - Deployed application"
 
 deploy-tomcat-internal:
     extends: .deploy-tomcat

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.7.RELEASE</version>
+        <version>2.7.18</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>uk.ac.ebi.eva</groupId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>3.6</version>
+            <version>3.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -80,7 +80,6 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jpa</artifactId>
-            <version>2.2.7.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -95,38 +94,19 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>5.3.3.RELEASE</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
-            <version>2.10.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.10.5</version>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-data-rest</artifactId>
-            <version>2.10.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-models</artifactId>
-            <version>1.6.2</version>
         </dependency>
 
         <!-- https://search.maven.org/artifact/org.springframework.boot/spring-boot-starter-hateoas -->

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/BaseController.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/BaseController.java
@@ -31,6 +31,8 @@ public class BaseController {
 
     public static final int DEFAULT_PAGE_SIZE = 10;
 
+    public static final int MAX_PAGE_SIZE = 1000;
+
     public static final String PAGE_NUMBER_DESCRIPTION = "You can provide a page index to return only a subset of" +
             " the data. Page numbers start from 0 and if not specified then default page number is 0.";
 
@@ -52,7 +54,7 @@ public class BaseController {
             pagex = page;
         }
         if (size != null) {
-            sizex = size;
+            sizex = Math.min(size, MAX_PAGE_SIZE);
         }
 
         // Even though this is redundant it is required for some integration tests to pass.

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/admin/AdminController.java
@@ -226,8 +226,8 @@ public class AdminController {
     @PutMapping(value = "chromosomes/{accession}/checksum")
     public void putChromosomeChecksumsByAccession(
             @PathVariable @Parameter(description ="INSDC or Refseq chromosome accession. Eg: NC_000001.11") String accession,
-            @RequestParam(required = false) @Parameter("The MD5 checksum associated with the chromosomes.") String md5,
-            @RequestParam(required = false) @Parameter("The TRUNC512 checksum associated with the chromosomes.") String trunc512) {
+            @RequestParam(required = false) @Parameter(description = "The MD5 checksum associated with the chromosomes.") String md5,
+            @RequestParam(required = false) @Parameter(description = "The TRUNC512 checksum associated with the chromosomes.") String trunc512) {
         handler.putChromosomeChecksumsByAccession(accession, md5, trunc512);
     }
 

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/admin/AdminController.java
@@ -16,8 +16,8 @@
 
 package uk.ac.ebi.eva.contigalias.controller.admin;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -46,9 +46,9 @@ public class AdminController {
         this.handler = handler;
     }
 
-    @ApiOperation(value = "Fetch an assembly from remote server using its INSDC or RefSeq accession and insert " +
+    @Operation(summary ="Fetch an assembly from remote server using its INSDC or RefSeq accession and insert " +
             "into local database.",
-            notes = "Given an assembly's accession, this endpoint will fetch and add the assembly that matches that " +
+            description ="Given an assembly's accession, this endpoint will fetch and add the assembly that matches that " +
                     "accession into the local database. The accession can be either a INSDC or a RefSeq accession " +
                     "and the endpoint will automatically fetch the correct assembly from remote server. It will first" +
                     " search for the target assembly in the local database as trying to insert an assembly which " +
@@ -59,7 +59,7 @@ public class AdminController {
                     "already exists in the local database.")
     @PutMapping(value = "assemblies/{accession}")
     public ResponseEntity<?> fetchAndInsertAssemblyByAccession(
-            @PathVariable(name = "accession") @ApiParam(value = "INSDC or RefSeq assembly accession. Eg: " +
+            @PathVariable(name = "accession") @Parameter(description ="INSDC or RefSeq assembly accession. Eg: " +
                     "GCA_000001405.10") String asmAccession) throws IOException {
         try {
             handler.fetchAndInsertAssemblyByAccession(asmAccession);
@@ -72,9 +72,9 @@ public class AdminController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @ApiOperation(value = "Fetch assemblies from remote server using their INSDC or RefSeq accessions and insert " +
+    @Operation(summary ="Fetch assemblies from remote server using their INSDC or RefSeq accessions and insert " +
             "into local database.",
-            notes = "Given a list of assembly accessions, for every accession in the list this endpoint will fetch " +
+            description ="Given a list of assembly accessions, for every accession in the list this endpoint will fetch " +
                     "and add the assembly that matches that accession into the local database. The accession can be " +
                     "either a INSDC or RefSeq accession and the endpoint will automatically fetch the correct " +
                     "assembly from remote server. It will first search for the target assembly in the local database " +
@@ -85,7 +85,7 @@ public class AdminController {
                     "parallel manner.")
     @PutMapping(value = "assemblies")
     public ResponseEntity<?> fetchAndInsertAssemblyByAccession(
-            @RequestBody @ApiParam(value = "A JSON array of INSDC or RefSeq assembly accessions. " +
+            @RequestBody @Parameter(description ="A JSON array of INSDC or RefSeq assembly accessions. " +
                     "Eg: [\"GCA_000001405.10\",\"GCA_000001405.11\",\"GCA_000001405.12\"]") List<String> accessions) {
         if (accessions == null || accessions.size() <= 0) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -99,10 +99,10 @@ public class AdminController {
         return new ResponseEntity<>("Accession Processing Result : " + accessionResult, HttpStatus.MULTI_STATUS);
     }
 
-    @ApiOperation(value = "Given an assembly accession, retrieve MD5 checksum for all chromosomes belonging to assembly and update")
+    @Operation(summary ="Given an assembly accession, retrieve MD5 checksum for all chromosomes belonging to assembly and update")
     @PutMapping(value = "assemblies/md5checksum/{accession}")
     public ResponseEntity<String> retrieveAndInsertMd5ChecksumForAssembly(@PathVariable(name = "accession")
-                                                                          @ApiParam(value = "INSDC or RefSeq assembly accession. Eg: " +
+                                                                          @Parameter(description ="INSDC or RefSeq assembly accession. Eg: " +
                                                                                   "GCA_000001405.10") String asmAccession) {
         Optional<AssemblyEntity> assemblyOpt = handler.getAssemblyByAccession(asmAccession);
         if (assemblyOpt.isPresent()) {
@@ -115,10 +115,10 @@ public class AdminController {
         }
     }
 
-    @ApiOperation(value = "Given a list of assembly accessions, retrieve MD5 checksum for all chromosomes belonging to all the assemblies and update")
+    @Operation(summary ="Given a list of assembly accessions, retrieve MD5 checksum for all chromosomes belonging to all the assemblies and update")
     @PutMapping(value = "assemblies/md5checksum")
     public ResponseEntity<String> retrieveAndInsertMd5ChecksumForAssembly(
-            @RequestBody @ApiParam(value = "A JSON array of INSDC or RefSeq assembly accessions. " +
+            @RequestBody @Parameter(description ="A JSON array of INSDC or RefSeq assembly accessions. " +
                     "Eg: [\"GCA_000001405.10\",\"GCA_000001405.11\",\"GCA_000001405.12\"]") List<String> accessions) {
         if (accessions == null || accessions.size() <= 0) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -148,10 +148,10 @@ public class AdminController {
         return ResponseEntity.ok(responseText);
     }
 
-    @ApiOperation(value = "Given an assembly accession, retrieve ENA sequence name for all chromosomes belonging to assembly and update")
+    @Operation(summary ="Given an assembly accession, retrieve ENA sequence name for all chromosomes belonging to assembly and update")
     @PutMapping(value = "assemblies/ena-sequence-name/{accession}")
     public ResponseEntity<String> retrieveAndInsertENASequenceNameForAssembly(@PathVariable(name = "accession")
-                                                                              @ApiParam(value = "INSDC or RefSeq assembly accession. " +
+                                                                              @Parameter(description ="INSDC or RefSeq assembly accession. " +
                                                                                       "Eg: GCA_000001405.10") String asmAccession) {
         Optional<AssemblyEntity> assemblyOpt = handler.getAssemblyByAccession(asmAccession);
         if (assemblyOpt.isPresent()) {
@@ -164,10 +164,10 @@ public class AdminController {
         }
     }
 
-    @ApiOperation(value = "Given a list of assembly accessions, retrieve ENA sequence name for all chromosomes belonging to all the assemblies and update")
+    @Operation(summary ="Given a list of assembly accessions, retrieve ENA sequence name for all chromosomes belonging to all the assemblies and update")
     @PutMapping(value = "assemblies/ena-sequence-name")
     public ResponseEntity<String> retrieveAndInsertENASequenceNameForAssembly(
-            @RequestBody @ApiParam(value = "A JSON array of INSDC or RefSeq assembly accessions. " +
+            @RequestBody @Parameter(description ="A JSON array of INSDC or RefSeq assembly accessions. " +
                     "Eg: [\"GCA_000001405.10\",\"GCA_000001405.11\",\"GCA_000001405.12\"]") List<String> accessions) {
         if (accessions == null || accessions.size() <= 0) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -198,7 +198,7 @@ public class AdminController {
     }
 
 
-    @ApiOperation(value = "Retrieve list of Jobs that are running or scheduled to run")
+    @Operation(summary ="Retrieve list of Jobs that are running or scheduled to run")
     @GetMapping(value = "assemblies/scheduled-jobs")
     public ResponseEntity<List<String>> getMD5ChecksumUpdateTaskStatus() {
         List<String> scheduledJobStatus = handler.getScheduledJobStatus();
@@ -206,40 +206,40 @@ public class AdminController {
     }
 
 //    This endpoint can be enabled in the future when checksums for assemblies are added to the project.
-//    @ApiOperation(value = "Add MD5 and TRUNC512 checksums to an assembly by accession.",
-//            notes = "Given an INSDC or RefSeq accession along with a MD5 or a TRUNC512 checksum, this endpoint will
+//    @Operation(summary ="Add MD5 and TRUNC512 checksums to an assembly by accession.",
+//            description ="Given an INSDC or RefSeq accession along with a MD5 or a TRUNC512 checksum, this endpoint will
 //            " +
 //                    "add the given checksums to the assembly that matches the given INSDC or RefSeq accession.")
 //    @PutMapping(value = "assemblies/{accession}/checksum")
 //    public void putAssemblyChecksumsByAccession(
-//            @PathVariable @ApiParam(value = "INSDC or Refseq assembly accession. Eg: GCA_000001405.10") String
+//            @PathVariable @Parameter(description ="INSDC or Refseq assembly accession. Eg: GCA_000001405.10") String
 //            accession,
-//            @RequestParam(required = false) @ApiParam("The MD5 checksum associated with the assembly.") String md5,
-//            @RequestParam(required = false) @ApiParam("The TRUNC512 checksum associated with the assembly.") String
+//            @RequestParam(required = false) @Parameter("The MD5 checksum associated with the assembly.") String md5,
+//            @RequestParam(required = false) @Parameter("The TRUNC512 checksum associated with the assembly.") String
 //                    trunc512) {
 //        handler.putAssemblyChecksumsByAccession(accession, md5, trunc512);
 //    }
 
-    @ApiOperation(value = "Add MD5 and TRUNC512 checksums to all chromosomes by accession.",
-            notes = "Given an INSDC or RefSeq accession along with a MD5 or a TRUNC512 checksum, this endpoint will " +
+    @Operation(summary ="Add MD5 and TRUNC512 checksums to all chromosomes by accession.",
+            description ="Given an INSDC or RefSeq accession along with a MD5 or a TRUNC512 checksum, this endpoint will " +
                     "add the given checksums to all chromosomes that match the given INSDC or RefSeq accession.")
     @PutMapping(value = "chromosomes/{accession}/checksum")
     public void putChromosomeChecksumsByAccession(
-            @PathVariable @ApiParam(value = "INSDC or Refseq chromosome accession. Eg: NC_000001.11") String accession,
-            @RequestParam(required = false) @ApiParam("The MD5 checksum associated with the chromosomes.") String md5,
-            @RequestParam(required = false) @ApiParam("The TRUNC512 checksum associated with the chromosomes.") String trunc512) {
+            @PathVariable @Parameter(description ="INSDC or Refseq chromosome accession. Eg: NC_000001.11") String accession,
+            @RequestParam(required = false) @Parameter("The MD5 checksum associated with the chromosomes.") String md5,
+            @RequestParam(required = false) @Parameter("The TRUNC512 checksum associated with the chromosomes.") String trunc512) {
         handler.putChromosomeChecksumsByAccession(accession, md5, trunc512);
     }
 
-    @ApiOperation(value = "Delete an assembly from local database using its INSDC or RefSeq accession.",
-            notes = "Given an assembly's accession this endpoint will delete the assembly that matches that " +
+    @Operation(summary ="Delete an assembly from local database using its INSDC or RefSeq accession.",
+            description ="Given an assembly's accession this endpoint will delete the assembly that matches that " +
                     "accession from the local database. The accession can be either a INSDC or RefSeq accession and" +
                     " the endpoint will automatically deletes the correct assembly from the database. Deleting an " +
                     "assembly also deletes all sequences that are associated with that assembly. This endpoint does" +
                     " not return any data.")
     @DeleteMapping(value = "assemblies/{accession}")
     public ResponseEntity<String> deleteAssemblyByAccession(
-            @PathVariable(name = "accession") @ApiParam(value = "INSDC or RefSeq assembly accession. Eg: " +
+            @PathVariable(name = "accession") @Parameter(description ="INSDC or RefSeq assembly accession. Eg: " +
                     "GCA_000001405.10") String asmAccession) {
         Optional<AssemblyEntity> assemblyOpt = handler.getAssemblyByAccession(asmAccession);
         if (assemblyOpt.isPresent()) {

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/admin/AdminController.java
@@ -106,12 +106,13 @@ public class AdminController {
                                                                                   "GCA_000001405.10") String asmAccession) {
         Optional<AssemblyEntity> assemblyOpt = handler.getAssemblyByAccession(asmAccession);
         if (assemblyOpt.isPresent()) {
-            handler.retrieveAndInsertMd5ChecksumForAssembly(assemblyOpt.get().getInsdcAccession());
-            return ResponseEntity.ok("A task has been submitted for updating md5checksum for assembly " + asmAccession
+            String insdcAccession = assemblyOpt.get().getInsdcAccession();
+            handler.retrieveAndInsertMd5ChecksumForAssembly(insdcAccession);
+            return ResponseEntity.ok("A task has been submitted for updating md5checksum for assembly " + insdcAccession
                     + "\nDepending upon the size of assembly and other scheduled jobs, this might take some time to complete");
         } else {
-            return ResponseEntity.ok("Could not find assembly " + asmAccession +
-                    ". Please insert the assembly first. MD5 checksum will be updated as part of the insertion process");
+            return ResponseEntity.ok("Could not find the requested assembly. " +
+                    "Please insert the assembly first. MD5 checksum will be updated as part of the insertion process");
         }
     }
 
@@ -137,12 +138,11 @@ public class AdminController {
 
         handler.retrieveAndInsertMd5ChecksumForAssembly(asmInsdcAccessionsList);
 
-        accessions.removeAll(asmNotPresent);
-        String responseText = "A task has been submitted for updating MD5 checksum for assemblies: " + accessions + "."
+        String responseText = "A task has been submitted for updating MD5 checksum for assemblies: " + asmInsdcAccessionsList + "."
                 + "\nDepending upon other scheduled jobs and the size of assembly, this might take some time to complete";
         if (!asmNotPresent.isEmpty()) {
-            responseText = responseText + "\nThe following assemblies are not present: " + asmNotPresent + "."
-                    + "\nPlease insert the assembly first, MD5 Checksum will be updated as part of the insertion process";
+            responseText = responseText + "\n" + asmNotPresent.size() + " assemblies were not found in the database."
+                    + "\nPlease insert the assemblies first, MD5 Checksum will be updated as part of the insertion process";
         }
 
         return ResponseEntity.ok(responseText);
@@ -155,12 +155,13 @@ public class AdminController {
                                                                                       "Eg: GCA_000001405.10") String asmAccession) {
         Optional<AssemblyEntity> assemblyOpt = handler.getAssemblyByAccession(asmAccession);
         if (assemblyOpt.isPresent()) {
-            handler.retrieveAndInsertENASequenceNameForAssembly(assemblyOpt.get().getInsdcAccession());
-            return ResponseEntity.ok("A task has been submitted for updating ENA Sequence Name for assembly " + asmAccession
+            String insdcAccession = assemblyOpt.get().getInsdcAccession();
+            handler.retrieveAndInsertENASequenceNameForAssembly(insdcAccession);
+            return ResponseEntity.ok("A task has been submitted for updating ENA Sequence Name for assembly " + insdcAccession
                     + "\nDepending upon the size of assembly and other scheduled jobs, this might take some time to complete");
         } else {
-            return ResponseEntity.ok("Could not find assembly " + asmAccession +
-                    ". Please insert the assembly first. ENA sequence name will be updated as part of the insertion process");
+            return ResponseEntity.ok("Could not find the requested assembly. " +
+                    "Please insert the assembly first. ENA sequence name will be updated as part of the insertion process");
         }
     }
 
@@ -186,12 +187,11 @@ public class AdminController {
 
         handler.retrieveAndInsertENASequenceNameForAssembly(asmInsdcAccessionsList);
 
-        accessions.removeAll(asmNotPresent);
-        String responseText = "A task has been submitted for updating ENA Sequence Name for assemblies: " + accessions
+        String responseText = "A task has been submitted for updating ENA Sequence Name for assemblies: " + asmInsdcAccessionsList
                 + "\nDepending upon other scheduled jobs and the size of assembly, this might take some time to complete";
         if (!asmNotPresent.isEmpty()) {
-            responseText = responseText + "\nThe following assemblies are not present: " + asmNotPresent + "."
-                    + "\nPlease insert the assembly first, ENA Sequence Name will be updated as part of the insertion process";
+            responseText = responseText + "\n" + asmNotPresent.size() + " assemblies were not found in the database."
+                    + "\nPlease insert the assemblies first, ENA Sequence Name will be updated as part of the insertion process";
         }
 
         return ResponseEntity.ok(responseText);

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/authentication/CustomBasicAuthenticationEntryPoint.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/authentication/CustomBasicAuthenticationEntryPoint.java
@@ -36,7 +36,7 @@ public class CustomBasicAuthenticationEntryPoint extends BasicAuthenticationEntr
         response.addHeader("WWW-Authenticate", "Basic realm=" + getRealmName() + "");
 
         PrintWriter writer = response.getWriter();
-        writer.println("HTTP Status 401 : " + authException.getMessage());
+        writer.println("HTTP Status 401 : Unauthorized");
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/authentication/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/authentication/SecurityConfiguration.java
@@ -18,7 +18,6 @@ package uk.ac.ebi.eva.contigalias.controller.authentication;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -26,7 +25,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -49,16 +47,12 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         this.customBasicAuthenticationEntryPoint = customBasicAuthenticationEntryPoint;
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
     @Autowired
     public void configureGlobalSecurity(AuthenticationManagerBuilder auth) throws Exception {
+        String encodedPassword = "{bcrypt}" + new BCryptPasswordEncoder().encode(PASSWORD_ADMIN);
         auth.inMemoryAuthentication()
             .withUser(USERNAME_ADMIN)
-            .password(passwordEncoder().encode(PASSWORD_ADMIN))
+            .password(encodedPassword)
             .roles(ROLE_ADMIN);
     }
 

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/authentication/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/authentication/SecurityConfiguration.java
@@ -18,12 +18,15 @@ package uk.ac.ebi.eva.contigalias.controller.authentication;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -46,18 +49,28 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         this.customBasicAuthenticationEntryPoint = customBasicAuthenticationEntryPoint;
     }
 
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
     @Autowired
     public void configureGlobalSecurity(AuthenticationManagerBuilder auth) throws Exception {
-        auth.inMemoryAuthentication().withUser(USERNAME_ADMIN).password("{noop}" + PASSWORD_ADMIN).roles(ROLE_ADMIN);
+        auth.inMemoryAuthentication()
+            .withUser(USERNAME_ADMIN)
+            .password(passwordEncoder().encode(PASSWORD_ADMIN))
+            .roles(ROLE_ADMIN);
     }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable()
             .authorizeRequests()
-            .antMatchers("/v1/assemblies/**").permitAll()
-            .antMatchers("/v1/chromosomes/**").permitAll()
+            .antMatchers("/v1/assemblies/**", "/v1/chromosomes/**", "/v1/search/**").permitAll()
+            .antMatchers("/info", "/health").permitAll()
+            .antMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
             .antMatchers("/v1/admin/**").hasRole(ROLE_ADMIN)
+            .anyRequest().denyAll()
             .and().httpBasic().realmName(REALM)
             .authenticationEntryPoint(customBasicAuthenticationEntryPoint)
             .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/contigalias/ContigAliasController.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/contigalias/ContigAliasController.java
@@ -16,8 +16,8 @@
 
 package uk.ac.ebi.eva.contigalias.controller.contigalias;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.hateoas.EntityModel;
@@ -84,18 +84,18 @@ public class ContigAliasController {
                                .withRel(REL_CHROMOSOMES));
     }
 
-    @ApiOperation(value = "Get an assembly using its INSDC or RefSeq accession. ",
-            notes = "Given an assembly's accession, this endpoint will return an assembly that matches that accession" +
+    @Operation(summary ="Get an assembly using its INSDC or RefSeq accession. ",
+            description ="Given an assembly's accession, this endpoint will return an assembly that matches that accession" +
                     ". The accession can be either a INSDC or RefSeq accession and the endpoint will automatically " +
                     "fetch a result from the database for any assembly having the accession as its INSDC or RefSeq " +
                     "accession. This endpoint will either return a list containing a single result or an HTTP status " +
                     "code of 404. ")
     @GetMapping(value = "assemblies/{accession}", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<AssemblyEntity>>> getAssemblyByAccession(
-            @PathVariable(name = "accession") @ApiParam(value = "INSDC or Refseq assembly accession. Eg: " +
+            @PathVariable(name = "accession") @Parameter(description ="INSDC or Refseq assembly accession. Eg: " +
                     "GCA_000001405.10") String asmAccession,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         if (paramsValidForSingleResponseQuery(pageNumber, pageSize)) {
             PagedModel<EntityModel<AssemblyEntity>> pagedModel = handler.getAssemblyByAccession(asmAccession);
             linkPagedModelGetSequencesByAssemblyAccession(asmAccession, pageNumber, pageSize, pagedModel, "");
@@ -103,15 +103,15 @@ public class ContigAliasController {
         } else return new ResponseEntity<>(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
     }
 
-    @ApiOperation(value = "Get an assembly using its INSDC accession.",
-            notes = "Given an assembly's INSDC accession, this endpoint will return an assembly that matches that " +
+    @Operation(summary ="Get an assembly using its INSDC accession.",
+            description ="Given an assembly's INSDC accession, this endpoint will return an assembly that matches that " +
                     "accession. This endpoint will either return a list containing a single result or an HTTP status " +
                     "code of 404. ")
     @GetMapping(value = "assemblies/insdc/{insdc}", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<AssemblyEntity>>> getAssemblyByInsdcAccession(
-            @PathVariable(name = "insdc") @ApiParam(value = "INSDC assembly accession. Eg: GCA_000001405.10") String asmInsdcAccession,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @PathVariable(name = "insdc") @Parameter(description ="INSDC assembly accession. Eg: GCA_000001405.10") String asmInsdcAccession,
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         if (paramsValidForSingleResponseQuery(pageNumber, pageSize)) {
             PagedModel<EntityModel<AssemblyEntity>> pagedModel = handler.getAssemblyByInsdcAccession(asmInsdcAccession);
             linkPagedModelGetSequencesByAssemblyAccession(
@@ -120,15 +120,15 @@ public class ContigAliasController {
         } else return new ResponseEntity<>(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
     }
 
-    @ApiOperation(value = "Get an assembly using its RefSeq accession.",
-            notes = "Given an assembly's RefSeq accession, this endpoint will return an assembly that matches that " +
+    @Operation(summary ="Get an assembly using its RefSeq accession.",
+            description ="Given an assembly's RefSeq accession, this endpoint will return an assembly that matches that " +
                     "accession. This endpoint will either return a list containing a single result or an HTTP status " +
                     "code of 404. ")
     @GetMapping(value = "assemblies/refseq/{refseq}", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<AssemblyEntity>>> getAssemblyByRefseq(
-            @PathVariable(name = "refseq") @ApiParam(value = "Refseq assembly accession. Eg: GCF_000001405.26") String asmRefseq,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @PathVariable(name = "refseq") @Parameter(description ="Refseq assembly accession. Eg: GCF_000001405.26") String asmRefseq,
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         if (paramsValidForSingleResponseQuery(pageNumber, pageSize)) {
             PagedModel<EntityModel<AssemblyEntity>> pagedModel = handler.getAssemblyByRefseq(asmRefseq);
             linkPagedModelGetSequencesByAssemblyAccession(
@@ -137,95 +137,95 @@ public class ContigAliasController {
         } else return new ResponseEntity<>(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
     }
 
-    @ApiOperation(value = "Get an assembly using its Taxonomic ID.",
-            notes = "Given an assembly's Taxonomic ID, this endpoint will return all assemblies that match the given " +
+    @Operation(summary ="Get an assembly using its Taxonomic ID.",
+            description ="Given an assembly's Taxonomic ID, this endpoint will return all assemblies that match the given " +
                     "Taxonomic ID. This endpoint will either return a list containing one or more assemblies or an " +
                     "HTTP status code of 404. ")
     @GetMapping(value = "assemblies/taxid/{taxid}", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<AssemblyEntity>>> getAssembliesByTaxid(
-            @PathVariable(name = "taxid") @ApiParam(value = "Taxonomic ID of a group of accessions. Eg: 9606") long asmTaxid,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @PathVariable(name = "taxid") @Parameter(description ="Taxonomic ID of a group of accessions. Eg: 9606") long asmTaxid,
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         PageRequest pageRequest = createPageRequest(pageNumber, pageSize);
         PagedModel<EntityModel<AssemblyEntity>> pagedModel = handler.getAssembliesByTaxid(asmTaxid, pageRequest);
         return createAppropriateResponseEntity(pagedModel);
     }
 
-    @ApiOperation(value = "Get a list of assemblies using the GenBank accession of one of the chromosomes they have " +
+    @Operation(summary ="Get a list of assemblies using the GenBank accession of one of the chromosomes they have " +
             "in common.",
-            notes = "Given a chromosome's GenBank accession, this endpoint will return a list of assemblies that are " +
+            description ="Given a chromosome's GenBank accession, this endpoint will return a list of assemblies that are " +
                     "associated with a chromosome having the same GenBank accession as the one provided. This " +
                     "endpoint returns a list containing one or more assemblies. It also accepts two additional " +
                     "parameters (page and size) to control pagination of results. If the page number and/or page size" +
                     " are invalid then an HTTP status code of 416 is returned by this endpoint.")
     @GetMapping(value = "chromosomes/genbank/{genbank}/assemblies")
     public ResponseEntity<PagedModel<EntityModel<AssemblyEntity>>> getAssembliesBySequenceGenbank
-            (@PathVariable @ApiParam(value = "GenBank accession of the chromosomes.") String genbank,
-             @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-             @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            (@PathVariable @Parameter(description ="GenBank accession of the chromosomes.") String genbank,
+             @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+             @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         if (paramsValidForSingleResponseQuery(pageNumber, pageSize)) {
             PagedModel<EntityModel<AssemblyEntity>> pagedModel = handler.getAssembliesBySequenceInsdcAccession(genbank);
             return createAppropriateResponseEntity(pagedModel);
         } else return new ResponseEntity<>(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
     }
 
-    @ApiOperation(value = "Get a list of assemblies using the RefSeq accession of one of the chromosomes they have " +
+    @Operation(summary ="Get a list of assemblies using the RefSeq accession of one of the chromosomes they have " +
             "in common.",
-            notes = "Given a chromosome's RefSeq accession, this endpoint will return a list of assemblies that are " +
+            description ="Given a chromosome's RefSeq accession, this endpoint will return a list of assemblies that are " +
                     "associated with a chromosome having the same RefSeq accession as the one provided. This " +
                     "endpoint returns a list containing one or more assemblies. It also accepts two additional " +
                     "parameters (page and size) to control pagination of results. If the page number and/or page size" +
                     " are invalid then an HTTP status code of 416 is returned by this endpoint.")
     @GetMapping(value = "chromosomes/refseq/{refseq}/assemblies")
     public ResponseEntity<PagedModel<EntityModel<AssemblyEntity>>> getAssembliesBySequenceRefseq(
-            @PathVariable @ApiParam(value = "RefSeq accession of the chromosomes.") String refseq,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @PathVariable @Parameter(description ="RefSeq accession of the chromosomes.") String refseq,
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         if (paramsValidForSingleResponseQuery(pageNumber, pageSize)) {
             PagedModel<EntityModel<AssemblyEntity>> pagedModel = handler.getAssembliesBySequenceRefseq(refseq);
             return createAppropriateResponseEntity(pagedModel);
         } else return new ResponseEntity<>(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
     }
 
-    @ApiOperation(value = "Get a list of chromosomes using their common GenBank accession.",
-            notes = "Given a chromosome's GenBank accession, this endpoint will return a list of all chromosomes that" +
+    @Operation(summary ="Get a list of chromosomes using their common GenBank accession.",
+            description ="Given a chromosome's GenBank accession, this endpoint will return a list of all chromosomes that" +
                     " match that accession. This endpoint will either return a list of chromosomes.")
     @GetMapping(value = "chromosomes/genbank/{genbank}", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> getSequencesByGenbank(
-            @PathVariable @ApiParam(value = "Genbank chromosome accession. Eg: CM000663.2") String genbank,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @PathVariable @Parameter(description ="Genbank chromosome accession. Eg: CM000663.2") String genbank,
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         PageRequest pageRequest = createPageRequest(pageNumber, pageSize);
         PagedModel<EntityModel<SequenceEntity>> pagedModel = handler.getSequencesByInsdcAccession(genbank, pageRequest);
         return createAppropriateResponseEntity(pagedModel);
     }
 
-    @ApiOperation(value = "Get a list of chromosomes using their common RefSeq accession.",
-            notes = "Given a chromosome's RefSeq accession, this endpoint will return a list of all chromosomes that " +
+    @Operation(summary ="Get a list of chromosomes using their common RefSeq accession.",
+            description ="Given a chromosome's RefSeq accession, this endpoint will return a list of all chromosomes that " +
                     "match that accession. This endpoint will either return a list of chromosomes.")
     @GetMapping(value = "chromosomes/refseq/{refseq}", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> getSequencesByRefseq(
-            @PathVariable @ApiParam(value = "Refseq chromosome accession. Eg: NC_000001.11") String refseq,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @PathVariable @Parameter(description ="Refseq chromosome accession. Eg: NC_000001.11") String refseq,
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         PageRequest pageRequest = createPageRequest(pageNumber, pageSize);
         PagedModel<EntityModel<SequenceEntity>> pagedModel = handler.getSequencesByRefseq(refseq, pageRequest);
         return createAppropriateResponseEntity(pagedModel);
     }
 
-    @ApiOperation(value = "Get chromosomes using the accession of its parent assembly.",
-            notes = "Given an assembly's INSDC or RefSeq accession, this endpoint will return a list of all the " +
+    @Operation(summary ="Get chromosomes using the accession of its parent assembly.",
+            description ="Given an assembly's INSDC or RefSeq accession, this endpoint will return a list of all the " +
                     "chromosomes that are associated with the assembly uniquely identified by the given accession. ")
     @GetMapping(value = "assemblies/{accession}/chromosomes", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> getSequencesByAssemblyAccession(
             @PathVariable(name = "accession") String asmAccession,
-            @RequestParam(required = false, name = "authority") @ApiParam("Specify if the provided accession is a " +
+            @RequestParam(required = false, name = "authority") @Parameter("Specify if the provided accession is a " +
                     "INSDC or a RefSeq accession. The acceptable param values are " + AUTHORITY_INSDC + " " +
                     "and " + AUTHORITY_REFSEQ + " respectively. If this parameter is omitted then the results having " +
                     "the given accession as either their INSDC or RefSeq accession are returned. This includes " +
                     "cases where the INSDC and RefSeq accessions are the same.") String asmAuthority,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         if (asmAccession == null || asmAccession.isEmpty()) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
@@ -248,14 +248,14 @@ public class ContigAliasController {
         return createAppropriateResponseEntity(pagedModel);
     }
 
-    @ApiOperation(value = "Get chromosomes using the insdc accession of its parent assembly.",
-            notes = "Given an assembly's INSDC accession, this endpoint will return a list of all the " +
+    @Operation(summary ="Get chromosomes using the insdc accession of its parent assembly.",
+            description ="Given an assembly's INSDC accession, this endpoint will return a list of all the " +
                     "chromosomes that are associated with the assembly uniquely identified by the given accession. ")
     @GetMapping(value = "assemblies/genbank/{genbank}/chromosomes", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> getSequencesByAssemblyGenbank(
             @PathVariable String genbank,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         PageRequest pageRequest = createPageRequest(pageNumber, pageSize);
         PagedModel<EntityModel<SequenceEntity>> pagedModel
                 = handler.getSequencesByAssemblyInsdcAccession(genbank, pageRequest);
@@ -263,14 +263,14 @@ public class ContigAliasController {
         return createAppropriateResponseEntity(pagedModel);
     }
 
-    @ApiOperation(value = "Get chromosomes using the refseq accession of its parent assembly.",
-            notes = "Given an assembly's RefSeq accession, this endpoint will return a list of all the " +
+    @Operation(summary ="Get chromosomes using the refseq accession of its parent assembly.",
+            description ="Given an assembly's RefSeq accession, this endpoint will return a list of all the " +
                     "chromosomes that are associated with the assembly uniquely identified by the given accession. ")
     @GetMapping(value = "assemblies/refseq/{refseq}/chromosomes", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> getSequencesByAssemblyRefseq(
             @PathVariable String refseq,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         PageRequest pageRequest = createPageRequest(pageNumber, pageSize);
         PagedModel<EntityModel<SequenceEntity>> pagedModel
                 = handler.getSequencesByAssemblyRefseq(refseq, pageRequest);
@@ -278,9 +278,9 @@ public class ContigAliasController {
         return createAppropriateResponseEntity(pagedModel);
     }
 
-    @ApiOperation(value = "Get chromosomes using a combination of their own name and the Taxonomic ID's of their " +
+    @Operation(summary ="Get chromosomes using a combination of their own name and the Taxonomic ID's of their " +
             "parent assemblies.",
-            notes = "Given a chromosome's name and the Taxonomic ID or the GenBank/RefSeq accession of the assembly " +
+            description ="Given a chromosome's name and the Taxonomic ID or the GenBank/RefSeq accession of the assembly " +
                     "that it belongs to, this endpoint will return a non-empty list of chromosomes that satisfy the " +
                     "given parameters. If no Taxonomic ID or accession are provided then the endpoint returns a list " +
                     "of chromosomes which have the given name. Each chromosome will also have its parent assembly " +
@@ -288,17 +288,17 @@ public class ContigAliasController {
                     "HTTP error code 400 if invalid parameters are found.")
     @GetMapping(value = "chromosomes/name/{name}")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> getSequencesBySequenceNameAndAssemblyTaxidOrAccession(
-            @PathVariable @ApiParam(value = "Sequence name or UCSC style name of chromosome. Eg: HSCHR1_RANDOM_CTG5") String name,
-            @RequestParam(required = false) @ApiParam(value = "Taxonomic ID of a group of accessions. Eg: 9606") Optional<Long> taxid,
-            @RequestParam(required = false, name = "accession") @ApiParam(value = "Genbank or Refseq assembly " +
+            @PathVariable @Parameter(description ="Sequence name or UCSC style name of chromosome. Eg: HSCHR1_RANDOM_CTG5") String name,
+            @RequestParam(required = false) @Parameter(description ="Taxonomic ID of a group of accessions. Eg: 9606") Optional<Long> taxid,
+            @RequestParam(required = false, name = "accession") @Parameter(description ="Genbank or Refseq assembly " +
                     "accession. Eg: GCA_000001405.10") Optional<String> asmAccession,
-            @RequestParam(required = false, name = "name") @ApiParam(value = "Specify if the provided name is an " +
+            @RequestParam(required = false, name = "name") @Parameter(description ="Specify if the provided name is an " +
                     "GenBank chromosome name, ENA name, or a UCSC style name. The acceptable param values are " +
                     NAME_GENBANK_TYPE + ", " + NAME_ENA_TYPE + ", and " +
                     NAME_UCSC_TYPE + " respectively. If this parameter is omitted then the name is assumed " +
                     "to be a " + NAME_GENBANK_TYPE + " name by default.") Optional<String> nameTypeOpt,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         boolean isNameValid = name != null && !name.isEmpty();
         boolean isTaxidValid = taxid.isPresent();
         boolean isAccessionValid = asmAccession.isPresent() && !asmAccession.get().isEmpty();
@@ -321,16 +321,16 @@ public class ContigAliasController {
 
     }
 
-    @ApiOperation(value = "Get a list of chromosomes using their MD5 checksum. ",
-            notes = "Given a chromosome's MD5 checksum, this endpoint will return a list of chromosomes that are " +
+    @Operation(summary ="Get a list of chromosomes using their MD5 checksum. ",
+            description ="Given a chromosome's MD5 checksum, this endpoint will return a list of chromosomes that are " +
                     "associated with the MD5 checksum provided. This endpoint returns a list containing one or more chromosomes. " +
                     "It also accepts two additional parameters (page and size) to control pagination of results. " +
                     "If the page number and/or page size are invalid then an HTTP status code of 416 is returned by this endpoint.")
     @GetMapping(value = "chromosomes/md5checksum/{md5Checksum}", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> getSequencesByMD5Checksum(
-            @PathVariable @ApiParam(value = "MD5 Checksum of chromosome Eg: 7b6e06758e53927330346e9e7cc00cce") String md5Checksum,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @PathVariable @Parameter(description ="MD5 Checksum of chromosome Eg: 7b6e06758e53927330346e9e7cc00cce") String md5Checksum,
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         PageRequest pageRequest = createPageRequest(pageNumber, pageSize);
         PagedModel<EntityModel<SequenceEntity>> pagedModel = handler.getSequencesByMD5Checksum(md5Checksum, pageRequest);
         return createAppropriateResponseEntity(pagedModel);
@@ -351,19 +351,19 @@ public class ContigAliasController {
         pagedModel.add(linkTo(method).withRel(REL_ASSEMBLY));
     }
 
-    @ApiOperation(value = "Search chromosome using its name", notes = "Given a chromosome's name/accession, " +
+    @Operation(summary ="Search chromosome using its name", description ="Given a chromosome's name/accession, " +
             "this endpoint will return a list of all chromosomes that match that name. " +
             "If provided, filtering will be done based on naming convention and assembly")
     @GetMapping(value = "search/chromosome/{name}",
             produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> searchChromosomeByName(
-            @PathVariable @ApiParam(value = "Chromosome name. Eg: CM000663.2") String name,
+            @PathVariable @Parameter(description ="Chromosome name. Eg: CM000663.2") String name,
             @RequestParam(required = false, name = "namingConvention")
-            @ApiParam(value = "Chromosome naming convention. Eg: refseq") String namingConvention,
+            @Parameter(description ="Chromosome naming convention. Eg: refseq") String namingConvention,
             @RequestParam(required = false, name = "assemblyAccession")
-            @ApiParam(value = "Assembly accession. Eg: GCA_000001405.10") String assemblyAccession,
-            @RequestParam(required = false, name = "page") @ApiParam(value = PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
-            @RequestParam(required = false, name = "size") @ApiParam(value = PAGE_SIZE_DESCRIPTION) Integer pageSize) {
+            @Parameter(description ="Assembly accession. Eg: GCA_000001405.10") String assemblyAccession,
+            @RequestParam(required = false, name = "page") @Parameter(description =PAGE_NUMBER_DESCRIPTION) Integer pageNumber,
+            @RequestParam(required = false, name = "size") @Parameter(description =PAGE_SIZE_DESCRIPTION) Integer pageSize) {
         PageRequest pageRequest = createPageRequest(pageNumber, pageSize);
         PagedModel<EntityModel<SequenceEntity>> pagedModel = handler.searchChromosomeByName(name, namingConvention,
                 assemblyAccession, pageRequest);

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/contigalias/ContigAliasController.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/contigalias/ContigAliasController.java
@@ -219,7 +219,7 @@ public class ContigAliasController {
     @GetMapping(value = "assemblies/{accession}/chromosomes", produces = "application/json")
     public ResponseEntity<PagedModel<EntityModel<SequenceEntity>>> getSequencesByAssemblyAccession(
             @PathVariable(name = "accession") String asmAccession,
-            @RequestParam(required = false, name = "authority") @Parameter("Specify if the provided accession is a " +
+            @RequestParam(required = false, name = "authority") @Parameter(description = "Specify if the provided accession is a " +
                     "INSDC or a RefSeq accession. The acceptable param values are " + AUTHORITY_INSDC + " " +
                     "and " + AUTHORITY_REFSEQ + " respectively. If this parameter is omitted then the results having " +
                     "the given accession as either their INSDC or RefSeq accession are returned. This includes " +

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/swagger/SwaggerConfig.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/swagger/SwaggerConfig.java
@@ -16,83 +16,48 @@
 
 package uk.ac.ebi.eva.contigalias.controller.swagger;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springdoc.core.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.util.UriComponentsBuilder;
-import springfox.documentation.PathProvider;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.paths.Paths;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc;
 
 @Configuration
-@EnableSwagger2WebMvc
 public class SwaggerConfig implements WebMvcConfigurer {
 
-    private final String CONTROLLER_BASE_PATH = "uk.ac.ebi.eva.contigalias.controller";
+    private static final String CONTROLLER_BASE_PATH = "uk.ac.ebi.eva.contigalias.controller";
 
     @Autowired
     SwaggerInterceptAdapter interceptAdapter;
 
-    @Value("${server.servlet.context-path:/}")
-    private String contextPath;
-
     @Bean
-    public Docket publicApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .groupName("v1/contigalias")
-                .pathProvider(getPathProvider())
-                .apiInfo(getApiInfo())
-                .select()
-                .apis(RequestHandlerSelectors.basePackage(CONTROLLER_BASE_PATH + ".contigalias"))
-                .paths(PathSelectors.any())
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("v1/contigalias")
+                .packagesToScan(CONTROLLER_BASE_PATH + ".contigalias")
                 .build();
     }
 
     @Bean
-    public Docket adminApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .groupName("v1/only-admins")
-                .pathProvider(getPathProvider())
-                .apiInfo(getApiInfo())
-                .select()
-                .apis(RequestHandlerSelectors.basePackage(CONTROLLER_BASE_PATH + ".admin"))
-                .paths(PathSelectors.any())
+    public GroupedOpenApi adminApi() {
+        return GroupedOpenApi.builder()
+                .group("v1/only-admins")
+                .packagesToScan(CONTROLLER_BASE_PATH + ".admin")
                 .build();
     }
 
-    private PathProvider getPathProvider() {
-        return new PathProvider() {
-            @Override
-            public String getOperationPath(String operationPath) {
-                if (operationPath.startsWith(contextPath)) {
-                    operationPath = operationPath.substring(contextPath.length());
-                }
-                return Paths.removeAdjacentForwardSlashes(
-                        UriComponentsBuilder.newInstance().replacePath(operationPath).build().toString());
-            }
-
-            @Override
-            public String getResourceListingPath(String groupName, String apiDeclaration) {
-                return null;
-            }
-        };
-    }
-
-    private ApiInfo getApiInfo() {
-        return new ApiInfoBuilder()
-                .title("Contig-Alias API")
-                .description(
-                        "Service to provide synonyms of chromosome/contig identifiers." +
+    @Bean
+    public OpenAPI contigAliasOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Contig-Alias API")
+                        .description(
+                                "Service to provide synonyms of chromosome/contig identifiers." +
                                 "\nThe endpoints in the following controllers are paginated, which means that all " +
                                 "results aren't returned at once, instead a small subset is returned. This small " +
                                 "subset in the form of a page and the result need to be traversed through this set of" +
@@ -107,16 +72,17 @@ public class SwaggerConfig implements WebMvcConfigurer {
                                 "\nSome information about pagination is also similarly included in a root level " +
                                 "object called \"page\". Due to this, the actual result is not available at the root " +
                                 "level but is actually embedded in another root level element.")
-                .version("1.0")
-                .contact(new Contact("GitHub Repository", "https://github.com/EBIvariation/contig-alias", null))
-                .license("Apache-2.0")
-                .licenseUrl("https://raw.githubusercontent.com/EBIvariation/contig-alias/master/LICENSE")
-                .build();
+                        .version("1.0")
+                        .contact(new Contact()
+                                .name("GitHub Repository")
+                                .url("https://github.com/EBIvariation/contig-alias"))
+                        .license(new License()
+                                .name("Apache-2.0")
+                                .url("https://raw.githubusercontent.com/EBIvariation/contig-alias/master/LICENSE")));
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(interceptAdapter);
     }
-
 }

--- a/src/main/java/uk/ac/ebi/eva/contigalias/controller/swagger/SwaggerInterceptAdapter.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/controller/swagger/SwaggerInterceptAdapter.java
@@ -36,7 +36,7 @@ public class SwaggerInterceptAdapter extends HandlerInterceptorAdapter {
 
         if (req.equals(contextPath) || req.equals(contextPath + "/") ||
                 req.equals(contextPath + "/v1") || req.equals(contextPath + "/v1/")) {
-            response.sendRedirect(contextPath + "/swagger-ui.html");
+            response.sendRedirect(contextPath + "/swagger-ui/index.html");
             return false;
         }
 

--- a/src/main/java/uk/ac/ebi/eva/contigalias/entities/AssemblyEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/entities/AssemblyEntity.java
@@ -17,9 +17,10 @@
 package uk.ac.ebi.eva.contigalias.entities;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
+import org.springframework.hateoas.server.core.Relation;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -30,40 +31,41 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.List;
 
+@Relation(collectionRelation = "assemblyEntities", itemRelation = "assemblyEntity")
 @Entity
 @Table(name = "assembly")
 public class AssemblyEntity {
 
     @Id
     @Column(nullable = false)
-    @ApiModelProperty(value = "Assembly's INSDC accession. It can be either a GenBank, ENA or a DDBJ accession.")
+    @Schema(description ="Assembly's INSDC accession. It can be either a GenBank, ENA or a DDBJ accession.")
     private String insdcAccession;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "The name of the assembly.")
+    @Schema(description ="The name of the assembly.")
     private String name;
 
-    @ApiModelProperty(value = "The organism of the assembly.")
+    @Schema(description ="The organism of the assembly.")
     private String organism;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "Assembly's taxonomic ID.")
+    @Schema(description ="Assembly's taxonomic ID.")
     private Long taxid;
 
-    @ApiModelProperty(value = "Assembly's Refseq accession.")
+    @Schema(description ="Assembly's Refseq accession.")
     private String refseq;
 
-    @ApiModelProperty(value = "Are assembly's INSDC and Refseq accessions identical")
+    @Schema(description ="Are assembly's INSDC and Refseq accessions identical")
     private boolean isGenbankRefseqIdentical;
 
-    @ApiModelProperty(value = "Assembly's MD5 checksum value.")
+    @Schema(description ="Assembly's MD5 checksum value.")
     private String md5checksum;
 
-    @ApiModelProperty(value = "Assembly's TRUNC512 checksum value.")
+    @Schema(description ="Assembly's TRUNC512 checksum value.")
     private String trunc512checksum;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @ApiModelProperty(value = "List of all chromosomes of the assembly present in the database.")
+    @Schema(description ="List of all chromosomes of the assembly present in the database.")
     @LazyCollection(LazyCollectionOption.TRUE)
     @OneToMany(mappedBy = "assembly", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<ChromosomeEntity> chromosomes;

--- a/src/main/java/uk/ac/ebi/eva/contigalias/entities/ChromosomeEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/entities/ChromosomeEntity.java
@@ -16,12 +16,15 @@
 
 package uk.ac.ebi.eva.contigalias.entities;
 
+import org.springframework.hateoas.server.core.Relation;
+
 import javax.persistence.Entity;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
 import java.io.Serializable;
 
 
+@Relation(collectionRelation = "chromosomeEntities", itemRelation = "chromosomeEntity")
 @Entity
 @Table(name = "chromosome")
 @IdClass(ChromosomeId.class)

--- a/src/main/java/uk/ac/ebi/eva/contigalias/entities/SequenceEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/contigalias/entities/SequenceEntity.java
@@ -17,7 +17,7 @@
 package uk.ac.ebi.eva.contigalias.entities;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -30,30 +30,30 @@ import javax.persistence.MappedSuperclass;
 @MappedSuperclass
 public class SequenceEntity {
 
-    @ApiModelProperty(value = "GenBank's name of the sequence.")
+    @Schema(description ="GenBank's name of the sequence.")
     private String genbankSequenceName;
 
-    @ApiModelProperty(value = "ENA's name of the sequence")
+    @Schema(description ="ENA's name of the sequence")
     private String enaSequenceName;
 
     @Id
     @Column(nullable = false)
-    @ApiModelProperty(value = "Sequence's INSDC accession.")
+    @Schema(description ="Sequence's INSDC accession.")
     private String insdcAccession;
 
-    @ApiModelProperty(value = "Sequence's RefSeq accession.")
+    @Schema(description ="Sequence's RefSeq accession.")
     private String refseq;
 
-    @ApiModelProperty(value = "Sequence's length")
+    @Schema(description ="Sequence's length")
     private Long seqLength;
 
-    @ApiModelProperty(value = "Sequence's UCSC style name")
+    @Schema(description ="Sequence's UCSC style name")
     private String ucscName;
 
-    @ApiModelProperty(value = "Sequence's MD5 checksum value.")
+    @Schema(description ="Sequence's MD5 checksum value.")
     private String md5checksum;
 
-    @ApiModelProperty(value = "Sequence's TRUNC512 checksum value.")
+    @Schema(description ="Sequence's TRUNC512 checksum value.")
     private String trunc512checksum;
 
     public enum ContigType {
@@ -61,13 +61,13 @@ public class SequenceEntity {
         CHROMOSOME
     }
 
-    @ApiModelProperty(value = "Type of contig: chromosome (or) scaffold")
+    @Schema(description ="Type of contig: chromosome (or) scaffold")
     @Enumerated(EnumType.STRING)
     private ContigType contigType;
 
     @Id
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @ApiModelProperty(value = "Assembly that this sequence belongs to.")
+    @Schema(description ="Assembly that this sequence belongs to.")
     @ManyToOne(cascade = CascadeType.ALL)
     private AssemblyEntity assembly;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,7 @@ controller.auth.admin.password=@contig-alias.admin-password@
 
 management.endpoints.web.exposure.include=info,health
 management.endpoints.web.base-path=/
-management.info.git.mode=full
+management.info.git.mode=simple
 
 logging.level.uk.ac.ebi.eva.contigalias=DEBUG
 

--- a/src/test/java/uk/ac/ebi/eva/contigalias/controller/contigalias/ContigAliasControllerIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/contigalias/controller/contigalias/ContigAliasControllerIntegrationTest.java
@@ -76,14 +76,14 @@ public class ContigAliasControllerIntegrationTest {
     @BeforeEach
     void setup() {
         PagedResourcesAssembler<AssemblyEntity> assemblyAssembler = mock(PagedResourcesAssembler.class);
-        PagedModel<EntityModel<AssemblyEntity>> assemblyPagedModel = new PagedModel<>(
-                Collections.singletonList(new EntityModel<>(assemblyEntity)), null);
+        PagedModel<EntityModel<AssemblyEntity>> assemblyPagedModel = PagedModel.of(
+                Collections.singletonList(EntityModel.of(assemblyEntity)), (PagedModel.PageMetadata) null);
         Mockito.when(assemblyAssembler.toModel(any()))
                .thenReturn(assemblyPagedModel);
 
         PagedResourcesAssembler<SequenceEntity> chromosomeAssembler = mock(PagedResourcesAssembler.class);
-        PagedModel<EntityModel<SequenceEntity>> chromosomePagedModel = new PagedModel<>(
-                Collections.singletonList(new EntityModel<>(chromosomeEntity)), null);
+        PagedModel<EntityModel<SequenceEntity>> chromosomePagedModel = PagedModel.of(
+                Collections.singletonList(EntityModel.of(chromosomeEntity)), (PagedModel.PageMetadata) null);
         Mockito.when(chromosomeAssembler.toModel(any()))
                .thenReturn(chromosomePagedModel);
 

--- a/src/test/java/uk/ac/ebi/eva/contigalias/controller/contigalias/ContigAliasHandlerTest.java
+++ b/src/test/java/uk/ac/ebi/eva/contigalias/controller/contigalias/ContigAliasHandlerTest.java
@@ -78,8 +78,8 @@ public class ContigAliasHandlerTest {
                    .thenReturn(optionalOfEntity);
 
             PagedResourcesAssembler<AssemblyEntity> assembler = mock(PagedResourcesAssembler.class);
-            PagedModel<EntityModel<AssemblyEntity>> pagedModel = new PagedModel<>(
-                    Collections.singletonList(new EntityModel<>(entity)), null);
+            PagedModel<EntityModel<AssemblyEntity>> pagedModel = PagedModel.of(
+                    Collections.singletonList(EntityModel.of(entity)), (PagedModel.PageMetadata) null);
             Mockito.when(assembler.toModel(any()))
                    .thenReturn(pagedModel);
             handler = new ContigAliasHandler(mockAssemblyService, null, assembler, null);
@@ -191,8 +191,8 @@ public class ContigAliasHandlerTest {
                    .thenReturn(pageOfEntity);
 
             PagedResourcesAssembler<SequenceEntity> mockSequencesAssembler = mock(PagedResourcesAssembler.class);
-            PagedModel<EntityModel<SequenceEntity>> sequencePagedModel = new PagedModel<>(
-                    Collections.singletonList(new EntityModel<>(entity)), null);
+            PagedModel<EntityModel<SequenceEntity>> sequencePagedModel = PagedModel.of(
+                    Collections.singletonList(EntityModel.of(entity)), (PagedModel.PageMetadata) null);
             Mockito.when(mockSequencesAssembler.toModel(any()))
                    .thenReturn(sequencePagedModel);
 
@@ -305,8 +305,8 @@ public class ContigAliasHandlerTest {
 
             PagedResourcesAssembler<AssemblyEntity> mockAssemblyAssembler = mock(PagedResourcesAssembler.class);
 
-            PagedModel<EntityModel<AssemblyEntity>> assemblyPagedModel = new PagedModel(
-                    Collections.singleton(new EntityModel<>(assemblyEntity)), null);
+            PagedModel<EntityModel<AssemblyEntity>> assemblyPagedModel = PagedModel.of(
+                    Collections.singleton(EntityModel.of(assemblyEntity)), (PagedModel.PageMetadata) null);
             Mockito.when(mockAssemblyAssembler.toModel(any()))
                    .thenReturn(assemblyPagedModel);
 


### PR DESCRIPTION
1. BCrypt password hashing (SecurityConfiguration.java)
The admin password was compared in plaintext ({noop}), making brute-force trivially fast. It is now hashed with BCrypt at startup, adding a computational cost to every login attempt.
2. Unbounded page size cap (BaseController.java)
Any unauthenticated caller could pass ?size=2147483647, forcing the database to attempt returning billions of rows. Page size is now capped at 1000.
3. Explicit security rules + deny-all catch-all (SecurityConfiguration.java)
The security config had no fallback rule, so any future endpoint added without an explicit rule would silently be public. All intended-public paths are now listed explicitly, and everything else is  blocked by anyRequest().denyAll().
4. Reduce actuator info exposure (application.properties)
/info was unauthenticated and returned full git metadata including commit messages. Changed to simple mode, which only exposes the short commit hash and timestamp.
5. HTTPS for Tomcat Manager deployment (.gitlab-ci.yml)
The WAR file and Tomcat Manager credentials were sent over HTTP. Changed to HTTPS since TLS is available on the Tomcat host.
6. Spring Boot 2.2.7 → 2.7.18 (pom.xml)
Spring Boot 2.2.7 has been end-of-life since November 2023. Upgrading to 2.7.18 (the last Spring Boot 2.x release, still Java 8 compatible) pulls in ~3.5 years of security patches across Spring Framework, Spring Security, Tomcat, and Jackson.
7. commons-net 3.6 → 3.10.0 (pom.xml)
The FTP client library was 7 years old. Updated to the current stable release.
8. Springfox replaced by springdoc-openapi 1.7.0 (pom.xml, SwaggerConfig.java, controllers)
Springfox has been abandoned since 2020 and is incompatible with Spring Boot 2.6+. Replaced with the actively maintained springdoc-openapi, which also required migrating the @ApiOperation/@ApiParam annotations to their OpenAPI 3 equivalents (@Operation/@Parameter).
9. Pinned spring-data-jpa version removed (pom.xml)
The explicit 2.2.7.RELEASE version pin overrode the Spring Boot BOM, meaning this library would not be upgraded automatically when the BOM was updated. Removed so it tracks the BOM.